### PR TITLE
Improve ingestion failure handling and retry flow

### DIFF
--- a/apps/web/src/app/api/sources/[id]/retry/route.ts
+++ b/apps/web/src/app/api/sources/[id]/retry/route.ts
@@ -1,0 +1,19 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { getAppContext } from "@/server/context";
+import { retrySourceProcessing } from "@/server/services/sources";
+
+export async function POST(_: Request, context: { params: Promise<{ id: string }> }) {
+  try {
+    const params = await context.params;
+    const result = await retrySourceProcessing(getAppContext(), params.id);
+    return NextResponse.json(result, { status: 202 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Retry failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -3,8 +3,10 @@ export const dynamic = "force-dynamic";
 import { CompileButton } from "@/components/compile-button";
 import { ImportForm } from "@/components/import-form";
 import { PageShell } from "@/components/page-shell";
+import { RetryButton } from "@/components/retry-button";
 import { SectionCard, StatusBadge } from "@/components/ui";
 import { getAppContext } from "@/server/context";
+import { parseJsonObject } from "@/server/services/common";
 import { listSources } from "@/server/services/sources";
 
 export default async function InboxPage() {
@@ -20,6 +22,14 @@ export default async function InboxPage() {
           <div className="space-y-4">
             {sources.map((source) => (
               <article key={source.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                {(() => {
+                  const metadata = parseJsonObject<Record<string, unknown>>(source.metadataJson, {});
+                  const normalization = metadata.normalization && typeof metadata.normalization === "object"
+                    ? (metadata.normalization as Record<string, unknown>)
+                    : null;
+
+                  return (
+                    <>
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="text-sm font-semibold">{source.title}</p>
@@ -35,10 +45,35 @@ export default async function InboxPage() {
                   隐私：{source.privacyLevel}
                   {source.projectKey ? ` · 项目：${source.projectKey}` : ""}
                 </p>
+                {normalization ? (
+                  <p className="mt-2 text-xs text-[var(--muted)]">
+                    解析：{String(normalization.parser ?? "unknown")}
+                    {typeof normalization.charCount === "number" ? ` · ${normalization.charCount} chars` : ""}
+                    {typeof normalization.wordCount === "number" ? ` · ${normalization.wordCount} words` : ""}
+                    {typeof normalization.pageCount === "number" ? ` · ${normalization.pageCount} pages` : ""}
+                  </p>
+                ) : null}
+                {source.latestJob ? (
+                  <p className="mt-2 text-xs text-[var(--muted)]">
+                    最新任务：{source.latestJob.jobType} · {source.latestJob.status}
+                    {source.latestJob.errorMessage ? ` · ${source.latestJob.errorMessage}` : ""}
+                  </p>
+                ) : null}
+                {source.errorMessage ? (
+                  <div className="mt-3 rounded-2xl bg-[var(--warn-soft)] px-4 py-3 text-sm text-[var(--warn)]">
+                    {source.errorMessage}
+                  </div>
+                ) : null}
                 <div className="mt-4 flex items-center justify-between gap-3">
                   <p className="line-clamp-2 text-sm leading-6 text-[var(--muted)]">{source.extractedText || source.originUrl || "待解析原文"}</p>
-                  <CompileButton sourceId={source.id} />
+                  <div className="flex items-center gap-2">
+                    <CompileButton sourceId={source.id} />
+                    {source.status === "failed" ? <RetryButton sourceId={source.id} /> : null}
+                  </div>
                 </div>
+                    </>
+                  );
+                })()}
               </article>
             ))}
             {sources.length === 0 ? <p className="text-sm text-[var(--muted)]">还没有任何 source。</p> : null}

--- a/apps/web/src/components/retry-button.tsx
+++ b/apps/web/src/components/retry-button.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export function RetryButton(props: { sourceId: string }) {
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        disabled={isPending}
+        className="rounded-full border border-[var(--line)] px-3 py-2 text-xs font-medium disabled:opacity-50"
+        onClick={() => {
+          startTransition(async () => {
+            const response = await fetch(`/api/sources/${props.sourceId}/retry`, {
+              method: "POST"
+            });
+            const payload = await response.json();
+            setMessage(response.ok ? `job:${payload.jobId}` : payload.error ?? "重试失败");
+          });
+        }}
+      >
+        {isPending ? "重试中..." : "重试"}
+      </button>
+      {message ? <span className="text-xs text-[var(--muted)]">{message}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/server/services/jobs.ts
+++ b/apps/web/src/server/services/jobs.ts
@@ -3,7 +3,7 @@ import { and, asc, eq } from "drizzle-orm";
 import type { JobType } from "@ai-knowledge-passport/shared";
 
 import type { AppContext } from "@/server/context";
-import { jobs } from "@/server/db/schema";
+import { jobs, sources } from "@/server/db/schema";
 
 import { createBackupRun } from "./backups";
 import { compileSource } from "./compiler";
@@ -65,6 +65,14 @@ async function performJob(context: AppContext, jobId: string) {
 }
 
 export async function runJob(context: AppContext, jobId: string) {
+  const job = await context.db.query.jobs.findFirst({
+    where: eq(jobs.id, jobId)
+  });
+
+  if (!job) {
+    throw new Error(`Job ${jobId} not found`);
+  }
+
   await context.db
     .update(jobs)
     .set({
@@ -72,6 +80,16 @@ export async function runJob(context: AppContext, jobId: string) {
       startedAt: nowIso()
     })
     .where(eq(jobs.id, jobId));
+
+  if (job.sourceId && job.jobType === "compile_source") {
+    await context.db
+      .update(sources)
+      .set({
+        status: "compiling",
+        errorMessage: null
+      })
+      .where(eq(sources.id, job.sourceId));
+  }
 
   try {
     await performJob(context, jobId);
@@ -96,6 +114,16 @@ export async function runJob(context: AppContext, jobId: string) {
         errorMessage: message
       })
       .where(eq(jobs.id, jobId));
+
+    if (job.sourceId) {
+      await context.db
+        .update(sources)
+        .set({
+          status: "failed",
+          errorMessage: message
+        })
+        .where(eq(sources.id, job.sourceId));
+    }
     throw error;
   }
 }
@@ -107,9 +135,19 @@ export async function drainQueue(context: AppContext, limit = 5) {
     limit
   });
 
+  const failures: Array<{ jobId: string; message: string }> = [];
   for (const job of pending) {
-    await runJob(context, job.id);
+    try {
+      await runJob(context, job.id);
+    } catch (error) {
+      failures.push({
+        jobId: job.id,
+        message: error instanceof Error ? error.message : "Unknown worker error"
+      });
+    }
   }
+
+  return failures;
 }
 
 export async function maybeRunInlineJobs(context: AppContext) {

--- a/apps/web/src/server/services/parsers.ts
+++ b/apps/web/src/server/services/parsers.ts
@@ -11,6 +11,11 @@ import { runCommand } from "@/server/utils/shell";
 
 const turndown = new TurndownService();
 
+type NormalizedSourceResult = {
+  text: string;
+  metadata: Record<string, string | number | boolean | null>;
+};
+
 async function renderPdfToImages(filePath: string) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "akp-pdf-"));
   const outputBase = path.join(tempDir, "page");
@@ -34,52 +39,138 @@ export async function normalizeSourceContent(
     textContent?: string | null;
     originUrl?: string | null;
   }
-) {
+): Promise<NormalizedSourceResult> {
   switch (input.type) {
     case "markdown":
     case "txt":
     case "chat":
-      return input.textContent?.trim() ?? "";
+      return {
+        text: input.textContent?.trim() ?? "",
+        metadata: {
+          parser: "inline_text",
+          charCount: input.textContent?.trim().length ?? 0,
+          wordCount: input.textContent?.trim().split(/\s+/).filter(Boolean).length ?? 0
+        }
+      };
     case "url": {
       if (!input.originUrl) {
-        return "";
+        return {
+          text: "",
+          metadata: {
+            parser: "url_fetch",
+            fetched: false
+          }
+        };
       }
       const response = await fetch(input.originUrl);
       const html = await response.text();
       const $ = cheerio.load(html);
+      const pageTitle = $("title").first().text().trim();
+      const description = $('meta[name="description"]').attr("content")?.trim() ?? null;
+      const author = $('meta[name="author"]').attr("content")?.trim() ?? null;
+      const htmlLang = $("html").attr("lang")?.trim() ?? null;
       $("script, style, noscript").remove();
       const markdown = turndown.turndown($("body").html() ?? "");
-      return markdown.trim();
+      const text = markdown.trim();
+      return {
+        text,
+        metadata: {
+          parser: "url_fetch",
+          fetched: true,
+          pageTitle,
+          description,
+          author,
+          htmlLang,
+          charCount: text.length
+        }
+      };
     }
     case "pdf": {
       if (!input.filePath) {
-        return "";
+        return {
+          text: "",
+          metadata: {
+            parser: "pdf",
+            extracted: false
+          }
+        };
       }
       const buffer = await fs.readFile(input.filePath);
       const parsed = await pdfParse(buffer);
       if (parsed.text.trim().length > 80) {
-        return parsed.text.trim();
+        const text = parsed.text.trim();
+        return {
+          text,
+          metadata: {
+            parser: "pdf_text",
+            pageCount: parsed.numpages,
+            charCount: text.length
+          }
+        };
       }
 
       const imagePaths = await renderPdfToImages(input.filePath);
       const ocrTexts = await Promise.all(imagePaths.map((imagePath) => ocrImageFile(imagePath)));
-      return ocrTexts.join("\n\n").trim();
+      const text = ocrTexts.join("\n\n").trim();
+      return {
+        text,
+        metadata: {
+          parser: "pdf_ocr",
+          pageCount: parsed.numpages,
+          ocrImageCount: imagePaths.length,
+          charCount: text.length
+        }
+      };
     }
     case "image": {
       if (!input.filePath) {
-        return "";
+        return {
+          text: "",
+          metadata: {
+            parser: "image_ocr",
+            extracted: false
+          }
+        };
       }
-      return ocrImageFile(input.filePath);
+      const text = await ocrImageFile(input.filePath);
+      return {
+        text,
+        metadata: {
+          parser: "image_ocr",
+          charCount: text.length,
+          wordCount: text.split(/\s+/).filter(Boolean).length
+        }
+      };
     }
     case "audio": {
       if (!input.filePath) {
-        return "";
+        return {
+          text: "",
+          metadata: {
+            parser: "audio_transcription",
+            extracted: false
+          }
+        };
       }
       const normalizedPath = `${input.filePath}.wav`;
       await runCommand("ffmpeg", ["-y", "-i", input.filePath, "-ac", "1", "-ar", "16000", normalizedPath]);
-      return context.provider.transcribeAudio({ filePath: normalizedPath, mimeType: "audio/wav" });
+      const text = await context.provider.transcribeAudio({ filePath: normalizedPath, mimeType: "audio/wav" });
+      return {
+        text,
+        metadata: {
+          parser: "audio_transcription",
+          normalizedAudioPath: normalizedPath,
+          charCount: text.length,
+          wordCount: text.split(/\s+/).filter(Boolean).length
+        }
+      };
     }
     default:
-      return "";
+      return {
+        text: "",
+        metadata: {
+          parser: "unknown"
+        }
+      };
   }
 }

--- a/apps/web/src/server/services/sources.ts
+++ b/apps/web/src/server/services/sources.ts
@@ -3,7 +3,7 @@ import { desc, eq, inArray } from "drizzle-orm";
 import type { ImportPayload } from "@ai-knowledge-passport/shared";
 
 import type { AppContext } from "@/server/context";
-import { sourceAssets, sourceFragments, sources } from "@/server/db/schema";
+import { jobs, sourceAssets, sourceFragments, sources } from "@/server/db/schema";
 import { chunkText, estimateTokens, stripMarkdown } from "@/server/utils/text";
 
 import { writeAuditLog } from "./audit";
@@ -141,14 +141,14 @@ export async function normalizeSource(context: AppContext, sourceId: string) {
   const metadata = parseJsonObject<Record<string, unknown>>(source.metadataJson, {});
   const textContent = typeof metadata.textContent === "string" ? metadata.textContent : undefined;
 
-  const extractedText = await normalizeSourceContent(context, {
+  const normalization = await normalizeSourceContent(context, {
     type: source.type as ImportPayload["type"],
     filePath: source.filePath,
     originUrl: source.originUrl,
     textContent
   });
 
-  const normalizedText = stripMarkdown(extractedText);
+  const normalizedText = stripMarkdown(normalization.text);
   const fragments = chunkText(normalizedText);
   const embeddings = context.provider.isConfigured && fragments.length > 0
     ? await context.provider.embedText(fragments)
@@ -182,7 +182,11 @@ export async function normalizeSource(context: AppContext, sourceId: string) {
     .set({
       extractedText: normalizedText,
       status: "ready_for_compile",
-      errorMessage: null
+      errorMessage: null,
+      metadataJson: JSON.stringify({
+        ...metadata,
+        normalization: normalization.metadata
+      })
     })
     .where(eq(sources.id, sourceId));
 
@@ -196,9 +200,21 @@ export async function normalizeSource(context: AppContext, sourceId: string) {
 }
 
 export async function listSources(context: AppContext) {
-  return context.db.query.sources.findMany({
+  const allSources = await context.db.query.sources.findMany({
     orderBy: [desc(sources.importedAt)]
   });
+  const sourceIds = allSources.map((source) => source.id);
+  const allJobs = sourceIds.length
+    ? await context.db.query.jobs.findMany({
+        where: inArray(jobs.sourceId, sourceIds),
+        orderBy: [desc(jobs.queuedAt)]
+      })
+    : [];
+
+  return allSources.map((source) => ({
+    ...source,
+    latestJob: allJobs.find((job) => job.sourceId === source.id) ?? null
+  }));
 }
 
 export async function getSourceDetails(context: AppContext, sourceId: string) {
@@ -208,10 +224,15 @@ export async function getSourceDetails(context: AppContext, sourceId: string) {
   const fragments = await context.db.query.sourceFragments.findMany({
     where: eq(sourceFragments.sourceId, sourceId)
   });
+  const sourceJobs = await context.db.query.jobs.findMany({
+    where: eq(jobs.sourceId, sourceId),
+    orderBy: [desc(jobs.queuedAt)]
+  });
 
   return {
     source,
-    fragments
+    fragments,
+    jobs: sourceJobs
   };
 }
 
@@ -222,4 +243,52 @@ export async function listSourcesByIds(context: AppContext, sourceIds: string[])
   return context.db.query.sources.findMany({
     where: inArray(sources.id, sourceIds)
   });
+}
+
+export async function retrySourceProcessing(context: AppContext, sourceId: string) {
+  const source = await context.db.query.sources.findFirst({
+    where: eq(sources.id, sourceId)
+  });
+
+  if (!source) {
+    throw new Error(`Source ${sourceId} not found`);
+  }
+
+  const latestJob = await context.db.query.jobs.findFirst({
+    where: eq(jobs.sourceId, sourceId),
+    orderBy: [desc(jobs.queuedAt)]
+  });
+
+  const jobType = latestJob?.jobType === "compile_source" || Boolean(source.extractedText)
+    ? "compile_source"
+    : "normalize_source";
+
+  await context.db
+    .update(sources)
+    .set({
+      status: jobType === "compile_source" ? "ready_for_compile" : "pending_ingest",
+      errorMessage: null
+    })
+    .where(eq(sources.id, sourceId));
+
+  const jobId = await enqueueJob(context, {
+    jobType,
+    sourceId
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "retry_source",
+    objectType: "source",
+    objectId: sourceId,
+    result: "queued",
+    notes: `job:${jobId}`
+  });
+
+  await maybeRunInlineJobs(context);
+
+  return {
+    sourceId,
+    jobId,
+    auditId
+  };
 }

--- a/apps/web/src/server/tests/mvp.test.ts
+++ b/apps/web/src/server/tests/mvp.test.ts
@@ -10,7 +10,7 @@ import { createOutput } from "@/server/services/outputs";
 import { createPassportSnapshot } from "@/server/services/passports";
 import { createPostcard } from "@/server/services/postcards";
 import { answerResearchQuery } from "@/server/services/research";
-import { createSourceImport, listSources } from "@/server/services/sources";
+import { createSourceImport, listSources, retrySourceProcessing } from "@/server/services/sources";
 
 import { describe, expect, it } from "vitest";
 
@@ -176,5 +176,38 @@ describe("knowledge passport MVP flow", () => {
     expect(backupId).toMatch(/^backup_/);
     const backupFiles = await fs.readdir(path.join(dataDir, "backups"));
     expect(backupFiles.some((entry) => entry.endsWith(".zip"))).toBe(true);
+  });
+
+  it("marks failed ingestion attempts and allows retry", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "akp-test-fail-"));
+    const dataDir = path.join(tempRoot, "data");
+    await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+    const context = createAppContext({
+      dataDir,
+      databasePath: path.join(dataDir, "test.sqlite"),
+      provider: new FakeProvider()
+    });
+
+    const importResult = await createSourceImport(context, {
+      payload: {
+        type: "url",
+        title: "Broken URL",
+        originUrl: "https://127.0.0.1.invalid.example.localhost",
+        privacyLevel: "L1_LOCAL_AI",
+        tags: [],
+        metadata: {}
+      }
+    });
+
+    const afterFailure = await listSources(context);
+    expect(afterFailure[0]?.status).toBe("failed");
+    expect(afterFailure[0]?.errorMessage).toBeTruthy();
+    expect(afterFailure[0]?.latestJob?.status).toBe("failed");
+
+    const retryResult = await retrySourceProcessing(context, importResult.sourceId);
+    expect(retryResult.jobId).toMatch(/^job_/);
   });
 });


### PR DESCRIPTION
## Summary
- mark source imports as failed when ingestion jobs error instead of surfacing only a job failure
- add retry support for failed source processing through a dedicated source retry API and Inbox action
- store richer normalization metadata from url, pdf, image and audio parsing and surface the latest job state in Inbox
- add regression coverage for failed ingestion plus retry behavior

## Verification
- npm run typecheck
- npm run test
- npm run build