### PR TITLE
Add backup restore workflow

### DIFF
--- a/apps/web/src/app/api/backups/route.ts
+++ b/apps/web/src/app/api/backups/route.ts
@@ -2,10 +2,15 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 
-import { backupCreateSchema } from "@ai-knowledge-passport/shared";
+import { backupCreateSchema, backupRestoreSchema } from "@ai-knowledge-passport/shared";
 
 import { getAppContext } from "@/server/context";
-import { enqueueBackup } from "@/server/services/backups";
+import { enqueueBackup, listBackups, restoreBackupToDirectory } from "@/server/services/backups";
+
+export async function GET() {
+  const backups = await listBackups(getAppContext());
+  return NextResponse.json({ backups });
+}
 
 export async function POST(request: Request) {
   try {
@@ -15,6 +20,19 @@ export async function POST(request: Request) {
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Backup failed" },
+      { status: 400 }
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const payload = backupRestoreSchema.parse(await request.json());
+    const result = await restoreBackupToDirectory(getAppContext(), payload);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Restore failed" },
       { status: 400 }
     );
   }

--- a/apps/web/src/app/passport/page.tsx
+++ b/apps/web/src/app/passport/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import ReactMarkdown from "react-markdown";
 
+import { BackupRestoreForm } from "@/components/backup-restore-form";
 import { PageShell } from "@/components/page-shell";
 import { PassportControls } from "@/components/passport-controls";
 import { SectionCard, StatusBadge } from "@/components/ui";
@@ -18,7 +19,17 @@ export default async function PassportPage() {
     <PageShell currentPath="/passport" title="Passport & Backup" subtitle="Generate a lightweight knowledge passport and archive the current state safely">
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <SectionCard title="Passport and Backup Controls" description="Passport generation runs through the queue, and backups package the database, object files, and manifest.">
-          <PassportControls />
+          <div className="space-y-6">
+            <PassportControls />
+            <div className="rounded-3xl border border-[var(--line)] bg-white/70 p-4">
+              <p className="text-sm leading-6 text-[var(--muted)]">
+                Backup restore currently extracts a selected archive into a clean target directory instead of overwriting the live runtime.
+              </p>
+              <div className="mt-4">
+                <BackupRestoreForm />
+              </div>
+            </div>
+          </div>
         </SectionCard>
         <div className="space-y-6">
           <SectionCard title="Passport Snapshots" description="Human-readable Markdown and machine-readable manifests are stored together.">
@@ -60,8 +71,14 @@ export default async function PassportPage() {
             <div className="space-y-3">
               {backups.map((backup) => (
                 <article key={backup.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
-                  <p className="font-medium">{backup.filePath}</p>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-medium">{backup.filePath}</p>
+                    <StatusBadge>{backup.id}</StatusBadge>
+                  </div>
                   <p className="mt-2 text-[var(--muted)]">{backup.note}</p>
+                  <p className="mt-2 text-xs text-[var(--muted)]">
+                    Objects {backup.manifest.objectFileCount} · SHA {backup.manifest.databaseSha256.slice(0, 12)}...
+                  </p>
                 </article>
               ))}
               {backups.length === 0 ? <p className="text-sm text-[var(--muted)]">There is no backup history yet.</p> : null}

--- a/apps/web/src/components/backup-restore-form.tsx
+++ b/apps/web/src/components/backup-restore-form.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export function BackupRestoreForm() {
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        startTransition(async () => {
+          const response = await fetch("/api/backups", {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              backupId: formData.get("backupId"),
+              targetDir: formData.get("targetDir") || undefined
+            })
+          });
+          const payload = await response.json();
+          setMessage(response.ok ? `Restored to ${payload.targetDir}` : payload.error ?? "Restore failed");
+        });
+      }}
+    >
+      <label className="space-y-2 text-sm">
+        <span>Backup ID</span>
+        <input name="backupId" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="backup_xxxxx" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Restore Target Directory</span>
+        <input name="targetDir" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="Optional. Defaults to data/restores/<backupId>" />
+      </label>
+      <div className="flex items-center gap-4">
+        <button disabled={isPending} className="rounded-full border border-[var(--line)] px-5 py-3 text-sm font-medium disabled:opacity-50">
+          {isPending ? "Restoring..." : "Restore Backup"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/server/services/backups.ts
+++ b/apps/web/src/server/services/backups.ts
@@ -1,14 +1,29 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import crypto from "node:crypto";
 
 import AdmZip from "adm-zip";
 
 import type { AppContext } from "@/server/context";
-import { backupRuns, auditLogs, outputs, passportSnapshots, postcards, sources, wikiNodes } from "@/server/db/schema";
+import { backupRuns } from "@/server/db/schema";
 
 import { writeAuditLog } from "./audit";
 import { createId, nowIso } from "./common";
 import { enqueueJob, maybeRunInlineJobs } from "./jobs";
+
+type BackupManifest = {
+  backupId: string;
+  createdAt: string;
+  databasePath: string;
+  note: string;
+  databaseSha256: string;
+  objectFileCount: number;
+};
+
+async function fileSha256(filePath: string) {
+  const buffer = await fs.readFile(filePath);
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
 
 export async function enqueueBackup(context: AppContext, note: string) {
   const jobId = await enqueueJob(context, {
@@ -36,10 +51,15 @@ export async function createBackupRun(context: AppContext, note: string) {
   const backupId = createId("backup");
   const filename = `knowledge-passport-backup-${timestamp}.zip`;
   const filePath = path.join(context.paths.backupsDir, filename);
-  const manifest = {
+  const databaseSha256 = await fileSha256(context.paths.databasePath);
+  const objectEntries = await fs.readdir(context.paths.objectsDir, { recursive: true });
+  const manifest: BackupManifest = {
+    backupId,
     createdAt: nowIso(),
     databasePath: context.paths.databasePath,
-    note
+    note,
+    databaseSha256,
+    objectFileCount: objectEntries.filter((entry) => typeof entry === "string" && !entry.endsWith(".gitkeep")).length
   };
 
   await fs.mkdir(context.paths.backupsDir, { recursive: true });
@@ -71,5 +91,69 @@ export async function createBackupRun(context: AppContext, note: string) {
 }
 
 export async function listBackups(context: AppContext) {
-  return context.db.query.backupRuns.findMany();
+  const runs = await context.db.query.backupRuns.findMany();
+  return runs.map((run) => ({
+    ...run,
+    manifest: JSON.parse(run.manifestJson) as BackupManifest
+  }));
+}
+
+export async function restoreBackupToDirectory(
+  context: AppContext,
+  input: {
+    backupId: string;
+    targetDir?: string;
+  }
+) {
+  const backup = await context.db.query.backupRuns.findFirst({
+    where: (table, { eq }) => eq(table.id, input.backupId)
+  });
+
+  if (!backup) {
+    throw new Error(`Backup ${input.backupId} not found`);
+  }
+
+  const manifest = JSON.parse(backup.manifestJson) as BackupManifest;
+  const targetDir = input.targetDir
+    ? path.resolve(input.targetDir)
+    : path.join(context.paths.dataDir, "restores", input.backupId);
+
+  await fs.mkdir(targetDir, { recursive: true });
+  const zip = new AdmZip(backup.filePath);
+  zip.extractAllTo(targetDir, true);
+
+  const restoredDatabasePath = path.join(targetDir, path.basename(context.paths.databasePath));
+  const restoredManifestPath = path.join(targetDir, "manifest.json");
+  const restoredObjectsDir = path.join(targetDir, "objects");
+
+  const [databaseExists, manifestExists] = await Promise.all([
+    fs.access(restoredDatabasePath).then(() => true).catch(() => false),
+    fs.access(restoredManifestPath).then(() => true).catch(() => false)
+  ]);
+
+  if (!databaseExists || !manifestExists) {
+    throw new Error("The backup archive did not restore the expected database and manifest files.");
+  }
+
+  const restoredSha256 = await fileSha256(restoredDatabasePath);
+  const integrityOk = restoredSha256 === manifest.databaseSha256;
+
+  await writeAuditLog(context, {
+    actionType: "restore_backup",
+    objectType: "backup_run",
+    objectId: backup.id,
+    result: integrityOk ? "succeeded" : "warning",
+    notes: targetDir
+  });
+
+  return {
+    backupId: backup.id,
+    targetDir,
+    restoredDatabasePath,
+    restoredManifestPath,
+    restoredObjectsDir,
+    integrityOk,
+    expectedDatabaseSha256: manifest.databaseSha256,
+    restoredDatabaseSha256: restoredSha256
+  };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -151,6 +151,11 @@ export const backupCreateSchema = z.object({
   note: z.string().default("manual_backup")
 });
 
+export const backupRestoreSchema = z.object({
+  backupId: z.string().min(1),
+  targetDir: z.string().optional()
+});
+
 export type PrivacyLevel = z.infer<typeof privacyLevelSchema>;
 export type SourceType = z.infer<typeof sourceTypeSchema>;
 export type SourceStatus = z.infer<typeof sourceStatusSchema>;
@@ -168,3 +173,4 @@ export type OutputCreateInput = z.infer<typeof outputCreateSchema>;
 export type PostcardCreateInput = z.infer<typeof postcardCreateSchema>;
 export type PassportGenerateInput = z.infer<typeof passportGenerateSchema>;
 export type BackupCreateInput = z.infer<typeof backupCreateSchema>;
+export type BackupRestoreInput = z.infer<typeof backupRestoreSchema>;


### PR DESCRIPTION
## Summary
- extend the backup API with restore support that extracts archives into a clean target directory
- add manifest integrity checks based on the backed-up database SHA256
- add a restore form and richer backup metadata to the Passport & Backup page
- add regression coverage for restore-to-clean-directory behavior

## Verification
- npm run typecheck
- npm run test
- npm run build