### PR TITLE
Add audit log center

### DIFF
--- a/apps/web/src/app/audit/page.tsx
+++ b/apps/web/src/app/audit/page.tsx
@@ -1,0 +1,80 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { getAuditSummary, listAuditLogs } from "@/server/services/audit";
+
+const filterLinks = [
+  { label: "All", href: "/audit" },
+  { label: "Failed", href: "/audit?result=failed" },
+  { label: "Warnings", href: "/audit?result=warning" },
+  { label: "Source Events", href: "/audit?objectType=source" },
+  { label: "Node Events", href: "/audit?objectType=wiki_node" },
+  { label: "Research Events", href: "/audit?objectType=research_session" }
+];
+
+export default async function AuditPage(props: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const searchParams = props.searchParams ? await props.searchParams : {};
+  const result = typeof searchParams.result === "string" ? searchParams.result : undefined;
+  const objectType = typeof searchParams.objectType === "string" ? searchParams.objectType : undefined;
+  const actionType = typeof searchParams.actionType === "string" ? searchParams.actionType : undefined;
+
+  const context = getAppContext();
+  const [summary, entries] = await Promise.all([
+    getAuditSummary(context),
+    listAuditLogs(context, {
+      result,
+      objectType,
+      actionType,
+      limit: 40
+    })
+  ]);
+
+  return (
+    <PageShell currentPath="/audit" title="Audit Log" subtitle="Inspect the event history for imports, compilation, review, research, exports, and restore operations">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Total Events" value={summary.total} />
+        <StatTile label="Failed Events" value={summary.failed} />
+        <StatTile label="Warnings" value={summary.warning} />
+        <StatTile label="Latest Event" value={summary.latest?.actionType ?? "none"} hint={summary.latest?.timestamp ?? "No audit records yet"} />
+      </section>
+
+      <SectionCard title="Quick Filters" description="Use these links to narrow the audit history by result or object type.">
+        <div className="flex flex-wrap gap-2">
+          {filterLinks.map((filter) => (
+            <Link key={filter.href} href={filter.href} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+              {filter.label}
+            </Link>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Recent Audit Entries" description="The most recent recorded events in the local system.">
+        <div className="space-y-3">
+          {entries.map((entry) => (
+            <article key={entry.id} className="rounded-2xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusBadge tone={entry.result === "failed" ? "warn" : entry.result === "succeeded" ? "success" : "default"}>
+                    {entry.result}
+                  </StatusBadge>
+                  <StatusBadge>{entry.objectType}</StatusBadge>
+                  <StatusBadge>{entry.actionType}</StatusBadge>
+                </div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{entry.timestamp}</p>
+              </div>
+              <p className="mt-3 font-medium">{entry.objectId}</p>
+              {entry.notes ? <p className="mt-2 text-[var(--muted)]">{entry.notes}</p> : null}
+            </article>
+          ))}
+          {entries.length === 0 ? <p className="text-sm text-[var(--muted)]">No audit entries match the current filter.</p> : null}
+        </div>
+      </SectionCard>
+    </PageShell>
+  );
+}

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Database, FileSearch, Files, HeartPulse, LayoutDashboard, LibraryBig, Shield } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Database, FileSearch, Files, HeartPulse, LayoutDashboard, LibraryBig, ScrollText, Shield } from "lucide-react";
 import clsx from "clsx";
 
 const navigation = [
@@ -13,6 +13,7 @@ const navigation = [
   { href: "/outputs", label: "Outputs", icon: BookOpenText },
   { href: "/postcards", label: "Postcards", icon: Activity },
   { href: "/health", label: "Health Center", icon: HeartPulse },
+  { href: "/audit", label: "Audit Log", icon: ScrollText },
   { href: "/passport", label: "Passport & Backup", icon: Shield }
 ];
 

--- a/apps/web/src/server/services/audit.ts
+++ b/apps/web/src/server/services/audit.ts
@@ -1,3 +1,5 @@
+import { desc, eq, sql } from "drizzle-orm";
+
 import { auditLogs } from "@/server/db/schema";
 import type { AppContext } from "@/server/context";
 
@@ -27,4 +29,53 @@ export async function writeAuditLog(
   });
 
   return auditId;
+}
+
+export async function listAuditLogs(
+  context: AppContext,
+  input?: {
+    result?: string;
+    objectType?: string;
+    actionType?: string;
+    limit?: number;
+  }
+) {
+  const limit = input?.limit ?? 50;
+  const allLogs = await context.db.query.auditLogs.findMany({
+    orderBy: [desc(auditLogs.timestamp)],
+    limit: limit * 3
+  });
+
+  return allLogs
+    .filter((entry) => !input?.result || entry.result === input.result)
+    .filter((entry) => !input?.objectType || entry.objectType === input.objectType)
+    .filter((entry) => !input?.actionType || entry.actionType === input.actionType)
+    .slice(0, limit);
+}
+
+export async function getAuditSummary(context: AppContext) {
+  const [totalRow] = await context.db
+    .select({ count: sql<number>`count(*)` })
+    .from(auditLogs);
+
+  const [failedRow] = await context.db
+    .select({ count: sql<number>`count(*)` })
+    .from(auditLogs)
+    .where(eq(auditLogs.result, "failed"));
+
+  const [warningRow] = await context.db
+    .select({ count: sql<number>`count(*)` })
+    .from(auditLogs)
+    .where(eq(auditLogs.result, "warning"));
+
+  const latest = await context.db.query.auditLogs.findFirst({
+    orderBy: [desc(auditLogs.timestamp)]
+  });
+
+  return {
+    total: totalRow?.count ?? 0,
+    failed: failedRow?.count ?? 0,
+    warning: warningRow?.count ?? 0,
+    latest
+  };
 }

--- a/apps/web/src/server/tests/audit.test.ts
+++ b/apps/web/src/server/tests/audit.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { getAuditSummary, listAuditLogs, writeAuditLog } from "@/server/services/audit";
+
+import { describe, expect, it } from "vitest";
+
+class StubProvider implements ModelProvider {
+  readonly isConfigured = false;
+  async extractStructured() { return { summary: "", keyClaims: [], concepts: [], themes: [], tags: [] }; }
+  async summarizeAndLink() { return { nodes: [], relationHints: [] }; }
+  async embedText() { return []; }
+  async transcribeAudio() { return ""; }
+  async generateAnswer() { return { answerMd: "", citations: [] }; }
+  async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
+  async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+}
+
+describe("audit service", () => {
+  it("lists and summarizes audit events with filters", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "akp-audit-"));
+    const dataDir = path.join(tempRoot, "data");
+    await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+    const context = createAppContext({
+      dataDir,
+      databasePath: path.join(dataDir, "test.sqlite"),
+      provider: new StubProvider()
+    });
+
+    await writeAuditLog(context, {
+      actionType: "import",
+      objectType: "source",
+      objectId: "src_1",
+      result: "succeeded"
+    });
+    await writeAuditLog(context, {
+      actionType: "compile_source",
+      objectType: "source",
+      objectId: "src_1",
+      result: "failed",
+      notes: "compile blew up"
+    });
+    await writeAuditLog(context, {
+      actionType: "restore_backup",
+      objectType: "backup_run",
+      objectId: "backup_1",
+      result: "warning"
+    });
+
+    const summary = await getAuditSummary(context);
+    const failedOnly = await listAuditLogs(context, { result: "failed" });
+
+    expect(summary.total).toBe(3);
+    expect(summary.failed).toBe(1);
+    expect(summary.warning).toBe(1);
+    expect(failedOnly).toHaveLength(1);
+    expect(failedOnly[0]?.notes).toContain("compile");
+  });
+});


### PR DESCRIPTION
## Summary
- add an Audit Log page that surfaces recent import, compile, review, research, export, backup, and restore events
- add audit summary metrics and simple result/object filters
- add audit service helpers for listing and summarizing audit entries
- add regression coverage for audit filtering and summary counts

## Verification
- npm run typecheck
- npm run test
- npm run build