### PR TITLE
Add visual knowledge map

### DIFF
--- a/apps/web/src/app/visuals/page.tsx
+++ b/apps/web/src/app/visuals/page.tsx
@@ -1,0 +1,102 @@
+export const dynamic = "force-dynamic";
+
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { getVisualOverview } from "@/server/services/visuals";
+
+export default async function VisualsPage() {
+  const overview = await getVisualOverview(getAppContext());
+
+  return (
+    <PageShell currentPath="/visuals" title="Visuals" subtitle="See the knowledge base as themes, evidence chains, privacy boundaries, and project reuse patterns">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Accepted Nodes" value={overview.summary.acceptedNodeCount} />
+        <StatTile label="Postcards" value={overview.summary.postcardCount} />
+        <StatTile label="Sources" value={overview.summary.sourceCount} />
+        <StatTile label="Theme Clusters" value={overview.summary.themeCount} />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Theme Map" description="Top topic clusters inferred from accepted node tags.">
+          <div className="grid gap-3 md:grid-cols-2">
+            {overview.themeClusters.map((cluster) => (
+              <article key={cluster.tag} className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium">{cluster.tag}</p>
+                  <StatusBadge tone="success">{cluster.count} nodes</StatusBadge>
+                </div>
+                <div className="mt-3 space-y-2">
+                  {cluster.nodes.map((node) => (
+                    <p key={node.id} className="text-sm text-[var(--muted)]">{node.title}</p>
+                  ))}
+                </div>
+              </article>
+            ))}
+            {overview.themeClusters.length === 0 ? <p className="text-sm text-[var(--muted)]">No theme clusters detected yet.</p> : null}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Privacy Boundary View" description="Distribution of sources, nodes, and postcards by privacy level.">
+          <div className="space-y-3">
+            {overview.privacyBoundary.map((entry) => (
+              <article key={entry.level} className="rounded-2xl border border-[var(--line)] bg-white/80 px-4 py-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <StatusBadge>{entry.level}</StatusBadge>
+                  <span className="text-[var(--muted)]">sources {entry.sourceCount} · nodes {entry.nodeCount} · cards {entry.postcardCount}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Evidence Chains" description="How postcards connect back to accepted nodes and original sources.">
+          <div className="space-y-4">
+            {overview.evidenceChains.map((chain) => (
+              <article key={chain.postcardId} className="rounded-2xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium">{chain.title}</p>
+                  <StatusBadge>{chain.cardType}</StatusBadge>
+                </div>
+                <p className="mt-2 text-[var(--muted)]">nodes {chain.nodeCount} · sources {chain.sourceCount}</p>
+                <div className="mt-3">
+                  <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Nodes</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {chain.nodes.map((node) => (
+                      <StatusBadge key={node.id}>{node.title}</StatusBadge>
+                    ))}
+                  </div>
+                </div>
+                <div className="mt-3">
+                  <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Sources</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {chain.sources.map((source) => (
+                      <StatusBadge key={source.id}>{source.title}</StatusBadge>
+                    ))}
+                  </div>
+                </div>
+              </article>
+            ))}
+            {overview.evidenceChains.length === 0 ? <p className="text-sm text-[var(--muted)]">No evidence chains are available yet.</p> : null}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Project Reuse" description="Where accepted nodes and postcards cluster across project scopes.">
+          <div className="space-y-3">
+            {overview.projectReuse.map((project) => (
+              <article key={project.projectKey} className="rounded-2xl border border-[var(--line)] bg-white/80 px-4 py-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium">{project.projectKey}</p>
+                  <span className="text-[var(--muted)]">nodes {project.nodeCount} · cards {project.postcardCount}</span>
+                </div>
+              </article>
+            ))}
+            {overview.projectReuse.length === 0 ? <p className="text-sm text-[var(--muted)]">No project reuse data yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Database, FileSearch, Files, HeartPulse, LayoutDashboard, LibraryBig, ScrollText, Shield } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Database, FileSearch, Files, HeartPulse, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints } from "lucide-react";
 import clsx from "clsx";
 
 const navigation = [
@@ -13,6 +13,7 @@ const navigation = [
   { href: "/outputs", label: "Outputs", icon: BookOpenText },
   { href: "/postcards", label: "Postcards", icon: Activity },
   { href: "/health", label: "Health Center", icon: HeartPulse },
+  { href: "/visuals", label: "Visuals", icon: Waypoints },
   { href: "/audit", label: "Audit Log", icon: ScrollText },
   { href: "/passport", label: "Passport & Backup", icon: Shield }
 ];

--- a/apps/web/src/server/services/visuals.ts
+++ b/apps/web/src/server/services/visuals.ts
@@ -1,0 +1,133 @@
+import type { PrivacyLevel } from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import { postcards, sources, wikiNodes } from "@/server/db/schema";
+
+import { parseJsonArray } from "./common";
+
+const orderedPrivacyLevels: PrivacyLevel[] = [
+  "L0_SELF",
+  "L1_LOCAL_AI",
+  "L2_INVITED",
+  "L3_PUBLIC",
+  "L4_AGENT_ONLY"
+];
+
+export async function getVisualOverview(context: AppContext) {
+  const [allNodes, allPostcards, allSources] = await Promise.all([
+    context.db.query.wikiNodes.findMany(),
+    context.db.query.postcards.findMany(),
+    context.db.query.sources.findMany()
+  ]);
+
+  const acceptedNodes = allNodes.filter((node) => node.status === "accepted");
+
+  const themeMap = new Map<string, Array<{ id: string; title: string }>>();
+  for (const node of acceptedNodes) {
+    const tags = parseJsonArray<string>(node.tagsJson);
+    for (const tag of tags) {
+      const existing = themeMap.get(tag) ?? [];
+      existing.push({ id: node.id, title: node.title });
+      themeMap.set(tag, existing);
+    }
+  }
+
+  const themeClusters = Array.from(themeMap.entries())
+    .map(([tag, nodes]) => ({
+      tag,
+      count: nodes.length,
+      nodes: nodes.slice(0, 5)
+    }))
+    .sort((left, right) => right.count - left.count)
+    .slice(0, 12);
+
+  const privacyBoundary = orderedPrivacyLevels.map((level) => ({
+    level,
+    nodeCount: acceptedNodes.filter((node) => node.privacyLevel === level).length,
+    postcardCount: allPostcards.filter((card) => card.privacyLevel === level).length,
+    sourceCount: allSources.filter((source) => source.privacyLevel === level).length
+  }));
+
+  const sourceMap = new Map(allSources.map((source) => [source.id, source]));
+  const nodeMap = new Map(acceptedNodes.map((node) => [node.id, node]));
+
+  const evidenceChains = allPostcards
+    .map((card) => {
+      const relatedNodeIds = parseJsonArray<string>(card.relatedNodeIdsJson);
+      const relatedSourceIds = new Set(parseJsonArray<string>(card.relatedSourceIdsJson));
+
+      const relatedNodes = relatedNodeIds
+        .map((id) => nodeMap.get(id))
+        .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+
+      for (const node of relatedNodes) {
+        for (const sourceId of parseJsonArray<string>(node.sourceIdsJson)) {
+          relatedSourceIds.add(sourceId);
+        }
+      }
+
+      return {
+        postcardId: card.id,
+        title: card.title,
+        cardType: card.cardType,
+        nodeCount: relatedNodes.length,
+        sourceCount: relatedSourceIds.size,
+        nodes: relatedNodes.slice(0, 4).map((node) => ({
+          id: node.id,
+          title: node.title
+        })),
+        sources: Array.from(relatedSourceIds)
+          .map((id) => sourceMap.get(id))
+          .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+          .slice(0, 4)
+          .map((source) => ({
+            id: source.id,
+            title: source.title
+          }))
+      };
+    })
+    .sort((left, right) => right.nodeCount + right.sourceCount - (left.nodeCount + left.sourceCount))
+    .slice(0, 8);
+
+  const projectMap = new Map<string, { nodeCount: number; postcardCount: number }>();
+  for (const node of acceptedNodes) {
+    const projectKey = node.projectKey ?? "unscoped";
+    const existing = projectMap.get(projectKey) ?? { nodeCount: 0, postcardCount: 0 };
+    existing.nodeCount += 1;
+    projectMap.set(projectKey, existing);
+  }
+  for (const card of allPostcards) {
+    const relatedNodeIds = parseJsonArray<string>(card.relatedNodeIdsJson);
+    const projectKeys = new Set(
+      relatedNodeIds
+        .map((id) => nodeMap.get(id)?.projectKey ?? "unscoped")
+    );
+    for (const projectKey of projectKeys) {
+      const existing = projectMap.get(projectKey) ?? { nodeCount: 0, postcardCount: 0 };
+      existing.postcardCount += 1;
+      projectMap.set(projectKey, existing);
+    }
+  }
+
+  const projectReuse = Array.from(projectMap.entries())
+    .map(([projectKey, counts]) => ({
+      projectKey,
+      nodeCount: counts.nodeCount,
+      postcardCount: counts.postcardCount
+    }))
+    .sort((left, right) => (right.nodeCount + right.postcardCount) - (left.nodeCount + left.postcardCount))
+    .slice(0, 12);
+
+  return {
+    summary: {
+      acceptedNodeCount: acceptedNodes.length,
+      postcardCount: allPostcards.length,
+      sourceCount: allSources.length,
+      themeCount: themeClusters.length
+    },
+    themeClusters,
+    privacyBoundary,
+    evidenceChains,
+    projectReuse
+  };
+}

--- a/apps/web/src/server/tests/visuals.test.ts
+++ b/apps/web/src/server/tests/visuals.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { wikiNodes, postcards, sources } from "@/server/db/schema";
+import { getVisualOverview } from "@/server/services/visuals";
+
+import { describe, expect, it } from "vitest";
+
+class StubProvider implements ModelProvider {
+  readonly isConfigured = false;
+  async extractStructured() { return { summary: "", keyClaims: [], concepts: [], themes: [], tags: [] }; }
+  async summarizeAndLink() { return { nodes: [], relationHints: [] }; }
+  async embedText() { return []; }
+  async transcribeAudio() { return ""; }
+  async generateAnswer() { return { answerMd: "", citations: [] }; }
+  async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
+  async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+}
+
+describe("visual overview", () => {
+  it("builds theme, privacy, evidence, and project summaries", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "akp-visuals-"));
+    const dataDir = path.join(tempRoot, "data");
+    await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+    const context = createAppContext({
+      dataDir,
+      databasePath: path.join(dataDir, "test.sqlite"),
+      provider: new StubProvider()
+    });
+
+    await context.db.insert(sources).values([
+      {
+        id: "src_1",
+        type: "markdown",
+        title: "Source One",
+        importedAt: new Date().toISOString(),
+        filePath: null,
+        privacyLevel: "L1_LOCAL_AI",
+        projectKey: "atlas",
+        hash: "hash-1",
+        status: "confirmed",
+        tagsJson: JSON.stringify(["maps"]),
+        metadataJson: "{}",
+        extractedText: "source one",
+        errorMessage: null
+      },
+      {
+        id: "src_2",
+        type: "markdown",
+        title: "Source Two",
+        importedAt: new Date().toISOString(),
+        filePath: null,
+        privacyLevel: "L3_PUBLIC",
+        projectKey: "atlas",
+        hash: "hash-2",
+        status: "confirmed",
+        tagsJson: JSON.stringify(["maps"]),
+        metadataJson: "{}",
+        extractedText: "source two",
+        errorMessage: null
+      }
+    ]);
+
+    await context.db.insert(wikiNodes).values([
+      {
+        id: "node_1",
+        nodeType: "theme",
+        title: "Knowledge Mapping",
+        summary: "Theme node",
+        bodyMd: "Body",
+        status: "accepted",
+        sourceIdsJson: JSON.stringify(["src_1", "src_2"]),
+        tagsJson: JSON.stringify(["maps", "passport"]),
+        projectKey: "atlas",
+        privacyLevel: "L3_PUBLIC",
+        embeddingJson: null,
+        updatedAt: new Date().toISOString(),
+        createdAt: new Date().toISOString()
+      }
+    ]);
+
+    await context.db.insert(postcards).values({
+      id: "card_1",
+      cardType: "knowledge",
+      title: "Mapping Card",
+      claim: "Claim",
+      evidenceSummary: "Evidence",
+      userView: "View",
+      relatedNodeIdsJson: JSON.stringify(["node_1"]),
+      relatedSourceIdsJson: JSON.stringify([]),
+      privacyLevel: "L3_PUBLIC",
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString()
+    });
+
+    const overview = await getVisualOverview(context);
+
+    expect(overview.summary.acceptedNodeCount).toBe(1);
+    expect(overview.summary.postcardCount).toBe(1);
+    expect(overview.themeClusters[0]?.tag).toBe("maps");
+    expect(overview.evidenceChains[0]?.sourceCount).toBe(2);
+    expect(overview.projectReuse[0]?.projectKey).toBe("atlas");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Visuals page for theme clusters, privacy boundaries, evidence chains, and project reuse patterns
- add a visual overview service that derives presentation data from accepted nodes, postcards, and sources
- add regression coverage for the visual summary pipeline
- expose the page through the primary app navigation

## Verification
- npm run typecheck
- npm run test
- npm run build