### PR TITLE
Fix TypeScript 6 verification settings

### DIFF
--- a/apps/web/src/types/styles.d.ts
+++ b/apps/web/src/types/styles.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,7 @@
     "noUncheckedIndexedAccess": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- raise `ignoreDeprecations` to `6.0` to match the installed TypeScript version
- add the missing `*.css` module declaration used by the Next app

## Notes
- this fixes two deterministic verification regressions surfaced during local workspace realignment
