### PR TITLE
Add avatar console and governed agent packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The public repository currently implements a single-user Web system with this en
 - Knowledge compilation, review queue, research Q&A, and output flowback
 - Postcard generation, passport snapshot generation, and backup zip exports
 - Visa bundle generation, managed secret-link sharing, machine-manifest downloads, and lightweight external flowback
+- Agent pack snapshots, avatar profiles, and governed internal-only simulation sessions
 - Fragment inspection, health diagnostics, audit history, and visual knowledge summaries
 - Next.js Web UI and a local worker
 
@@ -39,6 +40,7 @@ The current app shell includes:
 - `Audit Log`
 - `Passport & Backup`
 - `Visas`
+- `Avatars`
 - `Fragments`
 
 ## Architecture

--- a/apps/web/src/app/api/agent-packs/[id]/route.ts
+++ b/apps/web/src/app/api/agent-packs/[id]/route.ts
@@ -1,0 +1,17 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { getAppContext } from "@/server/context";
+import { getAgentPackSnapshot } from "@/server/services/agent-packs";
+
+export async function GET(_: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  const pack = await getAgentPackSnapshot(getAppContext(), params.id);
+
+  if (!pack) {
+    return NextResponse.json({ error: "Agent pack not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(pack);
+}

--- a/apps/web/src/app/api/agent-packs/route.ts
+++ b/apps/web/src/app/api/agent-packs/route.ts
@@ -1,0 +1,26 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { agentPackCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createAgentPackSnapshot, listAgentPacks } from "@/server/services/agent-packs";
+
+export async function GET() {
+  const packs = await listAgentPacks(getAppContext(), 80);
+  return NextResponse.json({ packs });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = agentPackCreateSchema.parse(await request.json());
+    const result = await createAgentPackSnapshot(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Agent pack creation failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/avatars/[id]/route.ts
+++ b/apps/web/src/app/api/avatars/[id]/route.ts
@@ -1,0 +1,33 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { avatarProfileUpdateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { getAvatarProfile, updateAvatarProfile } from "@/server/services/avatars";
+
+export async function GET(_: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  const avatar = await getAvatarProfile(getAppContext(), params.id);
+
+  if (!avatar) {
+    return NextResponse.json({ error: "Avatar profile not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(avatar);
+}
+
+export async function PATCH(request: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  try {
+    const payload = avatarProfileUpdateSchema.parse(await request.json());
+    const result = await updateAvatarProfile(getAppContext(), params.id, payload);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Avatar profile update failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/avatars/[id]/simulate/route.ts
+++ b/apps/web/src/app/api/avatars/[id]/simulate/route.ts
@@ -1,0 +1,22 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { avatarSimulationInputSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { simulateAvatar } from "@/server/services/avatars";
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  try {
+    const payload = avatarSimulationInputSchema.parse(await request.json());
+    const result = await simulateAvatar(getAppContext(), params.id, payload);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Avatar simulation failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/avatars/[id]/status/route.ts
+++ b/apps/web/src/app/api/avatars/[id]/status/route.ts
@@ -1,0 +1,22 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { avatarStatusUpdateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { setAvatarStatus } from "@/server/services/avatars";
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  try {
+    const payload = avatarStatusUpdateSchema.parse(await request.json());
+    const result = await setAvatarStatus(getAppContext(), params.id, payload.status);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Avatar status update failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/avatars/route.ts
+++ b/apps/web/src/app/api/avatars/route.ts
@@ -1,0 +1,26 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { avatarProfileCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createAvatarProfile, listAvatarProfiles } from "@/server/services/avatars";
+
+export async function GET() {
+  const avatars = await listAvatarProfiles(getAppContext(), 80);
+  return NextResponse.json({ avatars });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = avatarProfileCreateSchema.parse(await request.json());
+    const result = await createAvatarProfile(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Avatar profile creation failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/audit/page.tsx
+++ b/apps/web/src/app/audit/page.tsx
@@ -15,7 +15,10 @@ const filterLinks = [
   { label: "Node Events", href: "/audit?objectType=wiki_node" },
   { label: "Research Events", href: "/audit?objectType=research_session" },
   { label: "Visa Events", href: "/audit?objectType=visa_bundle" },
-  { label: "Visa Feedback", href: "/audit?objectType=visa_feedback" }
+  { label: "Visa Feedback", href: "/audit?objectType=visa_feedback" },
+  { label: "Avatar Profiles", href: "/audit?objectType=avatar_profile" },
+  { label: "Avatar Sessions", href: "/audit?objectType=avatar_simulation_session" },
+  { label: "Agent Packs", href: "/audit?objectType=agent_pack_snapshot" }
 ];
 
 export default async function AuditPage(props: {

--- a/apps/web/src/app/avatars/[id]/page.tsx
+++ b/apps/web/src/app/avatars/[id]/page.tsx
@@ -1,0 +1,164 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+
+import { AvatarProfileEditor } from "@/components/avatar-profile-editor";
+import { AvatarSimulationForm } from "@/components/avatar-simulation-form";
+import { AvatarStatusToggle } from "@/components/avatar-status-toggle";
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { getAgentPackSnapshot, listAgentPacks } from "@/server/services/agent-packs";
+import { getAvatarProfile, listAvatarSimulationSessions } from "@/server/services/avatars";
+
+export default async function AvatarDetailPage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  const context = getAppContext();
+  const [avatar, packs, sessions] = await Promise.all([
+    getAvatarProfile(context, params.id),
+    listAgentPacks(context, 80),
+    listAvatarSimulationSessions(context, params.id, 40)
+  ]);
+
+  if (!avatar) {
+    return (
+      <PageShell currentPath="/avatars" title="Avatar Console" subtitle="This avatar profile does not exist">
+        <SectionCard title="Missing Avatar">
+          <p className="text-sm text-[var(--muted)]">The requested avatar profile could not be found.</p>
+          <div className="mt-4">
+            <Link href="/avatars" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+              Back to Avatars
+            </Link>
+          </div>
+        </SectionCard>
+      </PageShell>
+    );
+  }
+
+  const activePack = await getAgentPackSnapshot(context, avatar.activePackId);
+  const answeredCount = sessions.filter((session) => session.resultStatus === "answered").length;
+  const refusedCount = sessions.filter((session) => session.resultStatus === "refused").length;
+  const escalatedCount = sessions.filter((session) => session.resultStatus === "escalated").length;
+
+  return (
+    <PageShell currentPath="/avatars" title="Avatar Console" subtitle="Inspect governed profile rules, active pack boundaries, and simulation outcomes">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Sessions" value={sessions.length} />
+        <StatTile label="Answered" value={answeredCount} />
+        <StatTile label="Refused" value={refusedCount} />
+        <StatTile label="Escalated" value={escalatedCount} />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Profile Summary" description="The avatar profile governs the pack boundary, tone, forbidden topics, and escalation behavior.">
+          <div className="space-y-4 text-sm">
+            <div className="flex flex-wrap gap-2">
+              <StatusBadge>{avatar.status}</StatusBadge>
+              <StatusBadge>{avatar.activePackId}</StatusBadge>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Title</p>
+              <p className="mt-1 font-medium">{avatar.title}</p>
+            </div>
+            {avatar.intro ? (
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Intro</p>
+                <p className="mt-1 leading-6">{avatar.intro}</p>
+              </div>
+            ) : null}
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Tone Rules</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {avatar.toneRules.map((rule) => (
+                  <StatusBadge key={rule}>{rule}</StatusBadge>
+                ))}
+                {avatar.toneRules.length === 0 ? <span className="text-[var(--muted)]">No tone rules</span> : null}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Forbidden Topics</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {avatar.forbiddenTopics.map((topic) => (
+                  <StatusBadge key={topic}>{topic}</StatusBadge>
+                ))}
+                {avatar.forbiddenTopics.length === 0 ? <span className="text-[var(--muted)]">None</span> : null}
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Forbidden Topic Rule</p>
+                <p className="mt-1">{avatar.escalationRules.escalateOnForbiddenTopic ? "Escalate" : "Refuse"}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Insufficient Evidence Rule</p>
+                <p className="mt-1">{avatar.escalationRules.escalateOnInsufficientEvidence ? "Escalate" : "Refuse"}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">Out-of-Scope Rule</p>
+                <p className="mt-1">{avatar.escalationRules.escalateOnOutOfScope ? "Escalate" : "Refuse"}</p>
+              </div>
+            </div>
+            <AvatarStatusToggle avatarId={avatar.id} status={avatar.status} />
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Active Agent Pack" description="This pack defines the evidence boundary available to the avatar simulator.">
+          {activePack ? (
+            <div className="space-y-4 text-sm">
+              <div className="flex flex-wrap gap-2">
+                <StatusBadge>{activePack.privacyFloor}</StatusBadge>
+                <StatusBadge>{activePack.id}</StatusBadge>
+              </div>
+              <p className="font-medium">{activePack.title}</p>
+              <p className="text-[var(--muted)]">Source passport: {activePack.sourcePassportId ?? "none"} · Source visa: {activePack.sourceVisaId ?? "none"}</p>
+              <div className="flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                <span className="rounded-full bg-black/5 px-3 py-1">nodes {activePack.includeNodeIds.length}</span>
+                <span className="rounded-full bg-black/5 px-3 py-1">cards {activePack.includePostcardIds.length}</span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-[var(--muted)]">The active pack could not be loaded.</p>
+          )}
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Edit Profile" description="Update the active pack, intro, tone rules, forbidden topics, and escalation behavior.">
+          <AvatarProfileEditor avatar={avatar} packs={packs.map((pack) => ({ id: pack.id, title: pack.title }))} />
+        </SectionCard>
+
+        <SectionCard title="Run Simulation" description="Simulate a single-turn governed exchange against the current avatar rules and pack scope.">
+          <AvatarSimulationForm avatarId={avatar.id} />
+        </SectionCard>
+      </div>
+
+      <SectionCard title="Recent Simulation Sessions" description="Every simulation is logged independently with answer, refusal, or escalation status and scoped citations.">
+        <div className="space-y-4">
+          {sessions.map((session) => (
+            <article key={session.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap gap-2">
+                  <StatusBadge>{session.resultStatus}</StatusBadge>
+                  <StatusBadge>{session.id}</StatusBadge>
+                </div>
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{session.createdAt}</p>
+              </div>
+              <p className="mt-3 font-medium">{session.question}</p>
+              {session.reason ? <p className="mt-2 text-[var(--muted)]">Reason: {session.reason}</p> : null}
+              <p className="mt-3 whitespace-pre-wrap leading-6">{session.answerMd}</p>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                {session.citations.map((citation) => (
+                  <span key={`${session.id}-${citation.refId}`} className="rounded-full bg-black/5 px-3 py-1">
+                    {citation.refId} · {citation.score.toFixed(2)}
+                  </span>
+                ))}
+                {session.citations.length === 0 ? <span className="text-[var(--muted)]">No citations</span> : null}
+              </div>
+            </article>
+          ))}
+          {sessions.length === 0 ? <p className="text-sm text-[var(--muted)]">No simulation sessions yet.</p> : null}
+        </div>
+      </SectionCard>
+    </PageShell>
+  );
+}

--- a/apps/web/src/app/avatars/page.tsx
+++ b/apps/web/src/app/avatars/page.tsx
@@ -1,0 +1,106 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+
+import { AgentPackForm } from "@/components/agent-pack-form";
+import { AvatarProfileForm } from "@/components/avatar-profile-form";
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { listAgentPacks } from "@/server/services/agent-packs";
+import { listAvatarProfiles } from "@/server/services/avatars";
+import { listPassports } from "@/server/services/passports";
+import { listVisaBundles } from "@/server/services/visas";
+
+export default async function AvatarsPage() {
+  const context = getAppContext();
+  const [packs, avatars, passports, visas, allSessions] = await Promise.all([
+    listAgentPacks(context, 80),
+    listAvatarProfiles(context, 80),
+    listPassports(context),
+    listVisaBundles(context, 80),
+    context.db.query.avatarSimulationSessions.findMany()
+  ]);
+
+  const activeProfiles = avatars.filter((avatar) => avatar.status === "active").length;
+  const recentEscalations = allSessions.filter((session) => session.resultStatus === "escalated").length;
+
+  return (
+    <PageShell currentPath="/avatars" title="Avatars" subtitle="Configure governed agent packs, bind them to avatar profiles, and simulate refusal and escalation behavior safely">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Agent Packs" value={packs.length} />
+        <StatTile label="Avatar Profiles" value={avatars.length} />
+        <StatTile label="Active Profiles" value={activeProfiles} />
+        <StatTile label="Escalations" value={recentEscalations} hint="Across all recorded simulations" />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Create Agent Pack" description="Snapshot a governed subset of passports, visas, nodes, and postcards as the knowledge boundary for a future avatar.">
+          <AgentPackForm
+            passports={passports.map((passport) => ({ id: passport.id, title: passport.title }))}
+            visas={visas.map((visa) => ({ id: visa.id, title: visa.title }))}
+          />
+        </SectionCard>
+
+        <SectionCard title="Create Avatar Profile" description="Bind an agent pack to a governed avatar identity with tone rules, forbidden topics, and escalation behavior.">
+          <AvatarProfileForm packs={packs.map((pack) => ({ id: pack.id, title: pack.title }))} />
+          {packs.length === 0 ? <p className="mt-4 text-sm text-[var(--muted)]">Create an agent pack first. Avatar profiles require an active pack.</p> : null}
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Agent Pack Registry" description="Frozen knowledge boundaries that future avatars can bind to.">
+          <div className="space-y-4">
+            {packs.map((pack) => (
+              <article key={pack.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{pack.title}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{pack.id}</p>
+                  </div>
+                  <StatusBadge>{pack.privacyFloor}</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm text-[var(--muted)]">
+                  Source passport: {pack.sourcePassportId ?? "none"} · Source visa: {pack.sourceVisaId ?? "none"}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">nodes {pack.includeNodeIds.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">cards {pack.includePostcardIds.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">{pack.createdAt}</span>
+                </div>
+              </article>
+            ))}
+            {packs.length === 0 ? <p className="text-sm text-[var(--muted)]">No agent packs exist yet.</p> : null}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Avatar Profile Registry" description="Each profile binds to one active pack and governs answer, refusal, and escalation behavior.">
+          <div className="space-y-4">
+            {avatars.map((avatar) => (
+              <article key={avatar.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{avatar.title}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{avatar.id}</p>
+                  </div>
+                  <StatusBadge>{avatar.status}</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm text-[var(--muted)]">Active pack: {avatar.activePackId}</p>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">tone {avatar.toneRules.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">forbidden {avatar.forbiddenTopics.length}</span>
+                </div>
+                <div className="mt-4">
+                  <Link href={`/avatars/${avatar.id}`} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+                    Open Console
+                  </Link>
+                </div>
+              </article>
+            ))}
+            {avatars.length === 0 ? <p className="text-sm text-[var(--muted)]">No avatar profiles exist yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/components/agent-pack-form.tsx
+++ b/apps/web/src/components/agent-pack-form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function AgentPackForm(props: {
+  passports: Array<{ id: string; title: string }>;
+  visas: Array<{ id: string; title: string }>;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+
+        startTransition(async () => {
+          const response = await fetch("/api/agent-packs", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              title: formData.get("title"),
+              passportId: formData.get("passportId") || undefined,
+              visaId: formData.get("visaId") || undefined,
+              includeNodeIds: String(formData.get("includeNodeIds") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              includePostcardIds: String(formData.get("includePostcardIds") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              privacyFloor: formData.get("privacyFloor")
+            })
+          });
+
+          const payload = await response.json();
+          if (response.ok) {
+            setMessage(`Agent pack created: ${payload.packId}`);
+            form.reset();
+            router.refresh();
+            return;
+          }
+          setMessage(payload.error ?? "Agent pack creation failed");
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2 text-sm">
+          <span>Pack Title</span>
+          <input name="title" defaultValue="Governed Agent Pack" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Privacy Floor</span>
+          <select name="privacyFloor" defaultValue="L1_LOCAL_AI" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="L0_SELF">L0_SELF</option>
+            <option value="L1_LOCAL_AI">L1_LOCAL_AI</option>
+            <option value="L2_INVITED">L2_INVITED</option>
+            <option value="L3_PUBLIC">L3_PUBLIC</option>
+            <option value="L4_AGENT_ONLY">L4_AGENT_ONLY</option>
+          </select>
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Source Passport</span>
+          <select name="passportId" defaultValue="" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="">None</option>
+            {props.passports.map((passport) => (
+              <option key={passport.id} value={passport.id}>
+                {passport.title} · {passport.id}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Source Visa</span>
+          <select name="visaId" defaultValue="" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="">None</option>
+            {props.visas.map((visa) => (
+              <option key={visa.id} value={visa.id}>
+                {visa.title} · {visa.id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="space-y-2 text-sm">
+        <span>Included Node IDs</span>
+        <input name="includeNodeIds" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="Leave empty to inherit from the selected passport or visa" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Included Postcard IDs</span>
+        <input name="includePostcardIds" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="Leave empty to inherit from the selected passport or visa" />
+      </label>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Creating..." : "Create Agent Pack"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/avatar-profile-editor.tsx
+++ b/apps/web/src/components/avatar-profile-editor.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AvatarProfileSummary } from "@ai-knowledge-passport/shared";
+
+export function AvatarProfileEditor(props: {
+  avatar: AvatarProfileSummary;
+  packs: Array<{ id: string; title: string }>;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        startTransition(async () => {
+          const response = await fetch(`/api/avatars/${props.avatar.id}`, {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              activePackId: formData.get("activePackId"),
+              intro: formData.get("intro") || "",
+              toneRules: String(formData.get("toneRules") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              forbiddenTopics: String(formData.get("forbiddenTopics") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              escalationRules: {
+                escalateOnForbiddenTopic: formData.get("escalateOnForbiddenTopic") === "on",
+                escalateOnInsufficientEvidence: formData.get("escalateOnInsufficientEvidence") === "on",
+                escalateOnOutOfScope: formData.get("escalateOnOutOfScope") === "on"
+              }
+            })
+          });
+
+          const payload = await response.json();
+          setMessage(response.ok ? "Avatar profile updated" : payload.error ?? "Update failed");
+          if (response.ok) {
+            router.refresh();
+          }
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2 text-sm">
+          <span>Active Agent Pack</span>
+          <select name="activePackId" defaultValue={props.avatar.activePackId} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            {props.packs.map((pack) => (
+              <option key={pack.id} value={pack.id}>
+                {pack.title} · {pack.id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="space-y-2 text-sm">
+        <span>Intro</span>
+        <textarea name="intro" rows={3} defaultValue={props.avatar.intro} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Tone Rules</span>
+        <input name="toneRules" defaultValue={props.avatar.toneRules.join(", ")} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Forbidden Topics</span>
+        <input name="forbiddenTopics" defaultValue={props.avatar.forbiddenTopics.join(", ")} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+
+      <div className="grid gap-3 rounded-3xl border border-[var(--line)] bg-white/80 p-4 md:grid-cols-2">
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnForbiddenTopic" defaultChecked={props.avatar.escalationRules.escalateOnForbiddenTopic} className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on forbidden topic</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnInsufficientEvidence" defaultChecked={props.avatar.escalationRules.escalateOnInsufficientEvidence} className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on insufficient evidence</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnOutOfScope" defaultChecked={props.avatar.escalationRules.escalateOnOutOfScope} className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on out-of-scope questions</span>
+        </label>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Saving..." : "Save Profile"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/avatar-profile-form.tsx
+++ b/apps/web/src/components/avatar-profile-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function AvatarProfileForm(props: {
+  packs: Array<{ id: string; title: string }>;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+
+        startTransition(async () => {
+          const response = await fetch("/api/avatars", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              title: formData.get("title"),
+              activePackId: formData.get("activePackId"),
+              intro: formData.get("intro") || "",
+              toneRules: String(formData.get("toneRules") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              forbiddenTopics: String(formData.get("forbiddenTopics") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              escalationRules: {
+                escalateOnForbiddenTopic: formData.get("escalateOnForbiddenTopic") === "on",
+                escalateOnInsufficientEvidence: formData.get("escalateOnInsufficientEvidence") === "on",
+                escalateOnOutOfScope: formData.get("escalateOnOutOfScope") === "on"
+              },
+              status: "active"
+            })
+          });
+
+          const payload = await response.json();
+          if (response.ok) {
+            setMessage(`Avatar created: ${payload.avatarId}`);
+            form.reset();
+            router.refresh();
+            return;
+          }
+          setMessage(payload.error ?? "Avatar creation failed");
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2 text-sm">
+          <span>Avatar Title</span>
+          <input name="title" defaultValue="Governed Avatar" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Active Agent Pack</span>
+          <select name="activePackId" required defaultValue={props.packs[0]?.id ?? ""} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            {props.packs.map((pack) => (
+              <option key={pack.id} value={pack.id}>
+                {pack.title} · {pack.id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="space-y-2 text-sm">
+        <span>Intro</span>
+        <textarea name="intro" rows={3} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Tone Rules</span>
+        <input name="toneRules" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="calm, concise, evidence-first" />
+      </label>
+      <label className="space-y-2 text-sm">
+        <span>Forbidden Topics</span>
+        <input name="forbiddenTopics" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="pricing, private clients, internal strategy" />
+      </label>
+
+      <div className="grid gap-3 rounded-3xl border border-[var(--line)] bg-white/80 p-4 md:grid-cols-2">
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnForbiddenTopic" defaultChecked className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on forbidden topic</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnInsufficientEvidence" defaultChecked className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on insufficient evidence</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="escalateOnOutOfScope" defaultChecked className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Escalate on out-of-scope questions</span>
+        </label>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending || props.packs.length === 0} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Creating..." : "Create Avatar"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/avatar-simulation-form.tsx
+++ b/apps/web/src/components/avatar-simulation-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AvatarSimulationSession } from "@ai-knowledge-passport/shared";
+
+export function AvatarSimulationForm(props: { avatarId: string }) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [latest, setLatest] = useState<AvatarSimulationSession | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div className="space-y-4">
+      <form
+        className="space-y-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+
+          startTransition(async () => {
+            const response = await fetch(`/api/avatars/${props.avatarId}/simulate`, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json"
+              },
+              body: JSON.stringify({
+                question: formData.get("question")
+              })
+            });
+            const payload = await response.json();
+            if (response.ok) {
+              setMessage(`Simulation: ${payload.resultStatus}`);
+              setLatest({
+                id: payload.sessionId,
+                avatarProfileId: props.avatarId,
+                question: String(formData.get("question") ?? ""),
+                resultStatus: payload.resultStatus,
+                answerMd: payload.answerMd,
+                citations: payload.citations,
+                reason: payload.reason,
+                createdAt: new Date().toISOString()
+              });
+              router.refresh();
+              return;
+            }
+            setMessage(payload.error ?? "Simulation failed");
+          });
+        }}
+      >
+        <label className="space-y-2 text-sm">
+          <span>Simulation Question</span>
+          <textarea name="question" rows={4} required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+        </label>
+        <div className="flex items-center gap-4">
+          <button disabled={isPending} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+            {isPending ? "Simulating..." : "Run Simulation"}
+          </button>
+          {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+        </div>
+      </form>
+
+      {latest ? (
+        <article className="rounded-2xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+          <p className="font-medium">Latest Result</p>
+          <p className="mt-2 text-[var(--muted)]">{latest.resultStatus}{latest.reason ? ` · ${latest.reason}` : ""}</p>
+          <p className="mt-3 whitespace-pre-wrap leading-6">{latest.answerMd}</p>
+        </article>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/avatar-status-toggle.tsx
+++ b/apps/web/src/components/avatar-status-toggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function AvatarStatusToggle(props: {
+  avatarId: string;
+  status: "active" | "paused";
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const nextStatus = props.status === "active" ? "paused" : "active";
+
+  return (
+    <div className="flex items-center gap-4">
+      <button
+        disabled={isPending}
+        className="rounded-full border border-[var(--line)] px-4 py-2 text-sm disabled:opacity-50"
+        onClick={() => {
+          startTransition(async () => {
+            const response = await fetch(`/api/avatars/${props.avatarId}/status`, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json"
+              },
+              body: JSON.stringify({ status: nextStatus })
+            });
+            const payload = await response.json();
+            setMessage(response.ok ? `Avatar ${nextStatus}` : payload.error ?? "Status update failed");
+            if (response.ok) {
+              router.refresh();
+            }
+          });
+        }}
+        type="button"
+      >
+        {isPending ? "Updating..." : nextStatus === "paused" ? "Pause Avatar" : "Activate Avatar"}
+      </button>
+      {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Database, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints, Workflow } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Bot, Database, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints, Workflow } from "lucide-react";
 import clsx from "clsx";
 
 const navigation = [
@@ -13,6 +13,7 @@ const navigation = [
   { href: "/outputs", label: "Outputs", icon: BookOpenText },
   { href: "/postcards", label: "Postcards", icon: Activity },
   { href: "/visas", label: "Visas", icon: Key },
+  { href: "/avatars", label: "Avatars", icon: Bot },
   { href: "/grants", label: "Grants", icon: Key },
   { href: "/compilation-runs", label: "Compilation Runs", icon: Workflow },
   { href: "/health", label: "Health Center", icon: HeartPulse },

--- a/apps/web/src/server/db/init.ts
+++ b/apps/web/src/server/db/init.ts
@@ -222,6 +222,43 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       updated_at text not null
     );
 
+    create table if not exists agent_pack_snapshots (
+      id text primary key,
+      title text not null,
+      source_passport_id text references passport_snapshots(id) on delete set null,
+      source_visa_id text references visa_bundles(id) on delete set null,
+      human_markdown text not null,
+      machine_manifest_json text not null,
+      include_node_ids_json text not null default '[]',
+      include_postcard_ids_json text not null default '[]',
+      privacy_floor text not null,
+      created_at text not null
+    );
+
+    create table if not exists avatar_profiles (
+      id text primary key,
+      title text not null,
+      active_pack_id text not null references agent_pack_snapshots(id) on delete restrict,
+      intro text not null default '',
+      tone_rules_json text not null default '[]',
+      forbidden_topics_json text not null default '[]',
+      escalation_rules_json text not null default '{}',
+      status text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+
+    create table if not exists avatar_simulation_sessions (
+      id text primary key,
+      avatar_profile_id text not null references avatar_profiles(id) on delete cascade,
+      question text not null,
+      result_status text not null,
+      answer_md text not null,
+      citations_json text not null default '[]',
+      reason text not null default '',
+      created_at text not null
+    );
+
     create table if not exists research_sessions (
       id text primary key,
       question text not null,

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -200,6 +200,43 @@ export const visaFeedbackQueue = sqliteTable("visa_feedback_queue", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const agentPackSnapshots = sqliteTable("agent_pack_snapshots", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  sourcePassportId: text("source_passport_id").references(() => passportSnapshots.id, { onDelete: "set null" }),
+  sourceVisaId: text("source_visa_id").references(() => visaBundles.id, { onDelete: "set null" }),
+  humanMarkdown: text("human_markdown").notNull(),
+  machineManifestJson: text("machine_manifest_json").notNull(),
+  includeNodeIdsJson: text("include_node_ids_json").notNull().default("[]"),
+  includePostcardIdsJson: text("include_postcard_ids_json").notNull().default("[]"),
+  privacyFloor: text("privacy_floor").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
+export const avatarProfiles = sqliteTable("avatar_profiles", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  activePackId: text("active_pack_id").notNull().references(() => agentPackSnapshots.id, { onDelete: "restrict" }),
+  intro: text("intro").notNull().default(""),
+  toneRulesJson: text("tone_rules_json").notNull().default("[]"),
+  forbiddenTopicsJson: text("forbidden_topics_json").notNull().default("[]"),
+  escalationRulesJson: text("escalation_rules_json").notNull().default("{}"),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const avatarSimulationSessions = sqliteTable("avatar_simulation_sessions", {
+  id: text("id").primaryKey(),
+  avatarProfileId: text("avatar_profile_id").notNull().references(() => avatarProfiles.id, { onDelete: "cascade" }),
+  question: text("question").notNull(),
+  resultStatus: text("result_status").notNull(),
+  answerMd: text("answer_md").notNull(),
+  citationsJson: text("citations_json").notNull().default("[]"),
+  reason: text("reason").notNull().default(""),
+  createdAt: text("created_at").notNull()
+});
+
 export const researchSessions = sqliteTable("research_sessions", {
   id: text("id").primaryKey(),
   question: text("question").notNull(),

--- a/apps/web/src/server/providers/model-provider.ts
+++ b/apps/web/src/server/providers/model-provider.ts
@@ -75,4 +75,14 @@ export interface ModelProvider {
     humanMarkdown: string;
     machineManifest: Record<string, unknown>;
   }>;
+  generateAvatarReply(input: {
+    avatarTitle: string;
+    intro: string;
+    toneRules: string[];
+    question: string;
+    evidence: Array<{ refId: string; title: string; text: string }>;
+  }): Promise<{
+    answerMd: string;
+    citations: ProviderCitation[];
+  }>;
 }

--- a/apps/web/src/server/providers/openai-provider.ts
+++ b/apps/web/src/server/providers/openai-provider.ts
@@ -34,7 +34,7 @@ export class OpenAIProvider implements ModelProvider {
 
   private ensureClient() {
     if (!this.client) {
-      throw new Error("OPENAI_API_KEY is required for AI compile, research, audio transcription and passport generation.");
+      throw new Error("OPENAI_API_KEY is required for AI compile, research, avatar simulation, audio transcription and passport generation.");
     }
 
     return this.client;
@@ -261,6 +261,53 @@ export class OpenAIProvider implements ModelProvider {
       machineManifest: response.machineManifest && typeof response.machineManifest === "object"
         ? (response.machineManifest as Record<string, unknown>)
         : {}
+    };
+  }
+
+  async generateAvatarReply(input: {
+    avatarTitle: string;
+    intro: string;
+    toneRules: string[];
+    question: string;
+    evidence: Array<{ refId: string; title: string; text: string }>;
+  }) {
+    const response = await this.jsonResponse<{
+      answerMd?: unknown;
+      citations?: unknown;
+    }>(
+      "You are simulating a governed digital avatar. Answer only from the supplied evidence, keep the response aligned with the avatar intro and tone rules, and do not invent claims beyond the evidence. Return markdown in answerMd and a citations array with refId, kind, excerpt, score. Use kind wiki_node for all citations.",
+      input
+    );
+
+    const citations = Array.isArray(response.citations)
+      ? response.citations.flatMap((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return [];
+          }
+
+          const candidate = entry as Record<string, unknown>;
+          const refId = typeof candidate.refId === "string" ? candidate.refId : "";
+          const excerpt = typeof candidate.excerpt === "string" ? candidate.excerpt : "";
+          const score = typeof candidate.score === "number" ? candidate.score : 0.5;
+
+          if (!refId || !excerpt) {
+            return [];
+          }
+
+          return [
+            {
+              refId,
+              kind: "wiki_node",
+              excerpt,
+              score
+            } satisfies ProviderCitation
+          ];
+        })
+      : [];
+
+    return {
+      answerMd: typeof response.answerMd === "string" ? response.answerMd.trim() : "",
+      citations
     };
   }
 }

--- a/apps/web/src/server/services/agent-packs.ts
+++ b/apps/web/src/server/services/agent-packs.ts
@@ -1,0 +1,281 @@
+import { eq, inArray } from "drizzle-orm";
+
+import type { AgentPackCreateInput, AgentPackSnapshot, AgentPackSummary, PrivacyLevel } from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import { agentPackSnapshots, passportSnapshots, postcards, visaBundles, wikiNodes } from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso, parseJsonArray } from "./common";
+import { canIncludeInPassport } from "./privacy";
+
+type PackNode = {
+  id: string;
+  title: string;
+  summary: string;
+  tags: string[];
+  projectKey: string | null;
+};
+
+type PackPostcard = {
+  id: string;
+  title: string;
+  claim: string;
+  cardType: string;
+  relatedNodeIds: string[];
+};
+
+function buildAgentPackHumanMarkdown(input: {
+  title: string;
+  sourcePassportId: string | null;
+  sourceVisaId: string | null;
+  nodes: PackNode[];
+  postcards: PackPostcard[];
+}) {
+  const lines: string[] = [
+    `# ${input.title}`,
+    "",
+    `Source passport: ${input.sourcePassportId ?? "none"}`,
+    `Source visa: ${input.sourceVisaId ?? "none"}`
+  ];
+
+  if (input.postcards.length) {
+    lines.push("", "## Postcards");
+    for (const card of input.postcards) {
+      lines.push("", `### ${card.title}`, "", card.claim, "", `Type: ${card.cardType}`);
+    }
+  }
+
+  if (input.nodes.length) {
+    lines.push("", "## Nodes");
+    for (const node of input.nodes) {
+      lines.push(
+        "",
+        `### ${node.title}`,
+        "",
+        node.summary,
+        "",
+        `Tags: ${node.tags.length ? node.tags.join(", ") : "None"}`,
+        `Project: ${node.projectKey ?? "None"}`
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function buildAgentPackMachineManifest(input: {
+  packId: string;
+  title: string;
+  sourcePassportId: string | null;
+  sourceVisaId: string | null;
+  privacyFloor: PrivacyLevel;
+  nodes: PackNode[];
+  postcards: PackPostcard[];
+}) {
+  return {
+    agentPackId: input.packId,
+    title: input.title,
+    generatedAt: nowIso(),
+    sourcePassportId: input.sourcePassportId,
+    sourceVisaId: input.sourceVisaId,
+    privacyFloor: input.privacyFloor,
+    stats: {
+      nodeCount: input.nodes.length,
+      postcardCount: input.postcards.length
+    },
+    nodes: input.nodes.map((node) => ({
+      id: node.id,
+      title: node.title,
+      summary: node.summary,
+      tags: node.tags,
+      projectKey: node.projectKey
+    })),
+    postcards: input.postcards.map((card) => ({
+      id: card.id,
+      title: card.title,
+      claim: card.claim,
+      cardType: card.cardType,
+      relatedNodeIds: card.relatedNodeIds
+    }))
+  };
+}
+
+async function resolveSourceSelections(
+  context: AppContext,
+  input: AgentPackCreateInput
+) {
+  if (input.passportId && input.visaId) {
+    throw new Error("Agent packs must be created from either one passport, one visa, or explicit selections.");
+  }
+
+  if (input.passportId) {
+    const passport = await context.db.query.passportSnapshots.findFirst({
+      where: eq(passportSnapshots.id, input.passportId)
+    });
+    if (!passport) {
+      throw new Error("Source passport snapshot not found.");
+    }
+    const useSnapshot = !input.includeNodeIds.length && !input.includePostcardIds.length;
+    return {
+      sourcePassportId: passport.id,
+      sourceVisaId: null,
+      includeNodeIds: useSnapshot ? parseJsonArray<string>(passport.includeNodeIdsJson) : input.includeNodeIds,
+      includePostcardIds: useSnapshot ? parseJsonArray<string>(passport.includePostcardIdsJson) : input.includePostcardIds
+    };
+  }
+
+  if (input.visaId) {
+    const visa = await context.db.query.visaBundles.findFirst({
+      where: eq(visaBundles.id, input.visaId)
+    });
+    if (!visa) {
+      throw new Error("Source visa bundle not found.");
+    }
+    const useSnapshot = !input.includeNodeIds.length && !input.includePostcardIds.length;
+    return {
+      sourcePassportId: null,
+      sourceVisaId: visa.id,
+      includeNodeIds: useSnapshot ? parseJsonArray<string>(visa.includeNodeIdsJson) : input.includeNodeIds,
+      includePostcardIds: useSnapshot ? parseJsonArray<string>(visa.includePostcardIdsJson) : input.includePostcardIds
+    };
+  }
+
+  return {
+    sourcePassportId: null,
+    sourceVisaId: null,
+    includeNodeIds: input.includeNodeIds,
+    includePostcardIds: input.includePostcardIds
+  };
+}
+
+function parsePackSummary(row: typeof agentPackSnapshots.$inferSelect): AgentPackSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    sourcePassportId: row.sourcePassportId ?? null,
+    sourceVisaId: row.sourceVisaId ?? null,
+    includeNodeIds: parseJsonArray<string>(row.includeNodeIdsJson),
+    includePostcardIds: parseJsonArray<string>(row.includePostcardIdsJson),
+    privacyFloor: row.privacyFloor as PrivacyLevel,
+    createdAt: row.createdAt
+  };
+}
+
+function parsePackSnapshot(row: typeof agentPackSnapshots.$inferSelect): AgentPackSnapshot {
+  return {
+    ...parsePackSummary(row),
+    humanMarkdown: row.humanMarkdown,
+    machineManifest: JSON.parse(row.machineManifestJson) as Record<string, unknown>
+  };
+}
+
+export async function createAgentPackSnapshot(context: AppContext, input: AgentPackCreateInput) {
+  const resolved = await resolveSourceSelections(context, input);
+  if (!resolved.includeNodeIds.length && !resolved.includePostcardIds.length) {
+    throw new Error("Agent packs must include at least one node or postcard, or inherit them from a source passport/visa.");
+  }
+
+  const nodeRows = resolved.includeNodeIds.length
+    ? await context.db.query.wikiNodes.findMany({
+        where: inArray(wikiNodes.id, resolved.includeNodeIds)
+      })
+    : [];
+  const postcardRows = resolved.includePostcardIds.length
+    ? await context.db.query.postcards.findMany({
+        where: inArray(postcards.id, resolved.includePostcardIds)
+      })
+    : [];
+
+  if (nodeRows.length !== resolved.includeNodeIds.length) {
+    throw new Error("One or more selected nodes could not be found.");
+  }
+  if (postcardRows.length !== resolved.includePostcardIds.length) {
+    throw new Error("One or more selected postcards could not be found.");
+  }
+  if (nodeRows.some((node) => node.status !== "accepted")) {
+    throw new Error("Agent packs can only include accepted nodes.");
+  }
+
+  const nodes: PackNode[] = nodeRows
+    .filter((node) => canIncludeInPassport(node.privacyLevel as PrivacyLevel, input.privacyFloor))
+    .map((node) => ({
+      id: node.id,
+      title: node.title,
+      summary: node.summary,
+      tags: parseJsonArray<string>(node.tagsJson),
+      projectKey: node.projectKey
+    }));
+
+  const cards: PackPostcard[] = postcardRows
+    .filter((card) => canIncludeInPassport(card.privacyLevel as PrivacyLevel, input.privacyFloor))
+    .map((card) => ({
+      id: card.id,
+      title: card.title,
+      claim: card.claim,
+      cardType: card.cardType,
+      relatedNodeIds: parseJsonArray<string>(card.relatedNodeIdsJson)
+    }));
+
+  if (!nodes.length && !cards.length) {
+    throw new Error("No selected content remained visible after applying the agent pack privacy floor.");
+  }
+
+  const packId = createId("pack");
+  const humanMarkdown = buildAgentPackHumanMarkdown({
+    title: input.title,
+    sourcePassportId: resolved.sourcePassportId,
+    sourceVisaId: resolved.sourceVisaId,
+    nodes,
+    postcards: cards
+  });
+  const machineManifest = buildAgentPackMachineManifest({
+    packId,
+    title: input.title,
+    sourcePassportId: resolved.sourcePassportId,
+    sourceVisaId: resolved.sourceVisaId,
+    privacyFloor: input.privacyFloor,
+    nodes,
+    postcards: cards
+  });
+
+  await context.db.insert(agentPackSnapshots).values({
+    id: packId,
+    title: input.title,
+    sourcePassportId: resolved.sourcePassportId,
+    sourceVisaId: resolved.sourceVisaId,
+    humanMarkdown,
+    machineManifestJson: JSON.stringify(machineManifest),
+    includeNodeIdsJson: JSON.stringify(nodes.map((node) => node.id)),
+    includePostcardIdsJson: JSON.stringify(cards.map((card) => card.id)),
+    privacyFloor: input.privacyFloor,
+    createdAt: nowIso()
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_agent_pack",
+    objectType: "agent_pack_snapshot",
+    objectId: packId,
+    result: "succeeded",
+    notes: input.title
+  });
+
+  return {
+    packId,
+    auditId
+  };
+}
+
+export async function listAgentPacks(context: AppContext, limit = 80) {
+  const rows = await context.db.query.agentPackSnapshots.findMany({
+    limit
+  });
+  return rows.map(parsePackSummary);
+}
+
+export async function getAgentPackSnapshot(context: AppContext, packId: string) {
+  const row = await context.db.query.agentPackSnapshots.findFirst({
+    where: eq(agentPackSnapshots.id, packId)
+  });
+  return row ? parsePackSnapshot(row) : null;
+}

--- a/apps/web/src/server/services/avatars.ts
+++ b/apps/web/src/server/services/avatars.ts
@@ -1,0 +1,505 @@
+import { desc, eq, inArray } from "drizzle-orm";
+
+import type {
+  AgentPackSnapshot,
+  AvatarProfileCreateInput,
+  AvatarProfileSummary,
+  AvatarProfileUpdateInput,
+  AvatarSimulationCitation,
+  AvatarSimulationInput,
+  AvatarSimulationSession,
+  AvatarSimulationStatus,
+  AvatarStatus
+} from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import {
+  agentPackSnapshots,
+  avatarProfiles,
+  avatarSimulationSessions,
+  postcards,
+  wikiNodes
+} from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso, parseJsonArray, parseJsonObject } from "./common";
+import { getAgentPackSnapshot } from "./agent-packs";
+
+type AvatarProfileRow = typeof avatarProfiles.$inferSelect;
+type AvatarSimulationSessionRow = typeof avatarSimulationSessions.$inferSelect;
+
+const defaultEscalationRules = {
+  escalateOnForbiddenTopic: true,
+  escalateOnInsufficientEvidence: true,
+  escalateOnOutOfScope: true
+};
+
+const stopwords = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "this",
+  "that",
+  "what",
+  "when",
+  "where",
+  "which",
+  "your",
+  "from",
+  "into",
+  "about",
+  "best"
+]);
+
+function parseProfile(row: AvatarProfileRow): AvatarProfileSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    activePackId: row.activePackId,
+    intro: row.intro,
+    toneRules: parseJsonArray<string>(row.toneRulesJson),
+    forbiddenTopics: parseJsonArray<string>(row.forbiddenTopicsJson),
+    escalationRules: parseJsonObject(row.escalationRulesJson, defaultEscalationRules),
+    status: row.status as AvatarStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function parseSimulationSession(row: AvatarSimulationSessionRow): AvatarSimulationSession {
+  return {
+    id: row.id,
+    avatarProfileId: row.avatarProfileId,
+    question: row.question,
+    resultStatus: row.resultStatus as AvatarSimulationStatus,
+    answerMd: row.answerMd,
+    citations: parseJsonArray<AvatarSimulationCitation>(row.citationsJson),
+    reason: row.reason,
+    createdAt: row.createdAt
+  };
+}
+
+function tokenizeQuestion(question: string) {
+  return question
+    .toLowerCase()
+    .split(/[\s,.;:!?()[\]{}"'，。；：！？、]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3)
+    .filter((token) => !stopwords.has(token));
+}
+
+function lexicalHits(text: string, tokens: string[]) {
+  const normalized = text.toLowerCase();
+  return tokens.filter((token) => normalized.includes(token)).length;
+}
+
+async function ensureAgentPackExists(context: AppContext, packId: string) {
+  const pack = await context.db.query.agentPackSnapshots.findFirst({
+    where: eq(agentPackSnapshots.id, packId)
+  });
+  if (!pack) {
+    throw new Error("Agent pack snapshot not found.");
+  }
+  return pack;
+}
+
+async function resolvePackEvidence(context: AppContext, pack: AgentPackSnapshot) {
+  const includedNodeIds = new Set(pack.includeNodeIds);
+  const includedCardIds = pack.includePostcardIds;
+  if (includedCardIds.length) {
+    const cardRows = await context.db.query.postcards.findMany({
+      where: inArray(postcards.id, includedCardIds)
+    });
+    for (const card of cardRows) {
+      for (const nodeId of parseJsonArray<string>(card.relatedNodeIdsJson)) {
+        includedNodeIds.add(nodeId);
+      }
+    }
+  }
+
+  const nodeIds = Array.from(includedNodeIds);
+  if (!nodeIds.length) {
+    return [];
+  }
+
+  const nodeRows = await context.db.query.wikiNodes.findMany({
+    where: inArray(wikiNodes.id, nodeIds)
+  });
+
+  return nodeRows
+    .filter((node) => node.status === "accepted")
+    .map((node) => ({
+      id: node.id,
+      title: node.title,
+      text: `${node.title}\n${node.summary}\n${node.bodyMd}`
+    }));
+}
+
+function classifyQuestion(
+  profile: AvatarProfileSummary,
+  scopedEvidence: Array<{ id: string; title: string; text: string }>,
+  question: string
+): {
+  kind: "answered" | "refused" | "escalated";
+  reason: string;
+  evidence: Array<{ id: string; title: string; text: string; hits?: number }>;
+} {
+  const normalizedQuestion = question.toLowerCase();
+  const forbiddenTopic = profile.forbiddenTopics.find((topic) => topic.trim() && normalizedQuestion.includes(topic.toLowerCase()));
+  if (forbiddenTopic) {
+    return {
+      kind: profile.escalationRules.escalateOnForbiddenTopic ? "escalated" : "refused",
+      reason: `forbidden_topic:${forbiddenTopic}`,
+      evidence: [] as Array<{ id: string; title: string; text: string }>
+    };
+  }
+
+  const tokens = tokenizeQuestion(question);
+  const scored = scopedEvidence
+    .map((entry) => ({
+      ...entry,
+      hits: lexicalHits(entry.text, tokens)
+    }))
+    .sort((left, right) => right.hits - left.hits);
+
+  const topHits = scored[0]?.hits ?? 0;
+  if (!scored.length) {
+    return {
+      kind: profile.escalationRules.escalateOnInsufficientEvidence ? "escalated" : "refused",
+      reason: "insufficient_evidence",
+      evidence: []
+    };
+  }
+
+  if (topHits === 0) {
+    return {
+      kind: profile.escalationRules.escalateOnOutOfScope ? "escalated" : "refused",
+      reason: "out_of_scope",
+      evidence: []
+    };
+  }
+
+  const requiredHits = Math.min(2, Math.max(tokens.length, 1));
+  if (topHits < requiredHits) {
+    return {
+      kind: profile.escalationRules.escalateOnInsufficientEvidence ? "escalated" : "refused",
+      reason: "insufficient_evidence",
+      evidence: scored.filter((entry) => entry.hits > 0).slice(0, 5)
+    };
+  }
+
+  return {
+    kind: "answered" as const,
+    reason: "",
+    evidence: scored.filter((entry) => entry.hits > 0).slice(0, 5)
+  };
+}
+
+async function createSimulationSession(
+  context: AppContext,
+  input: {
+    avatarProfileId: string;
+    question: string;
+    resultStatus: AvatarSimulationStatus;
+    answerMd: string;
+    citations: AvatarSimulationCitation[];
+    reason: string;
+  }
+) {
+  const sessionId = createId("avatar_session");
+  await context.db.insert(avatarSimulationSessions).values({
+    id: sessionId,
+    avatarProfileId: input.avatarProfileId,
+    question: input.question,
+    resultStatus: input.resultStatus,
+    answerMd: input.answerMd,
+    citationsJson: JSON.stringify(input.citations),
+    reason: input.reason,
+    createdAt: nowIso()
+  });
+
+  await writeAuditLog(context, {
+    actionType: "simulate_avatar",
+    objectType: "avatar_simulation_session",
+    objectId: sessionId,
+    result: "succeeded",
+    notes: input.resultStatus
+  });
+
+  if (input.resultStatus === "refused") {
+    await writeAuditLog(context, {
+      actionType: "refuse_avatar",
+      objectType: "avatar_profile",
+      objectId: input.avatarProfileId,
+      result: "succeeded",
+      notes: input.reason
+    });
+  }
+
+  if (input.resultStatus === "escalated") {
+    await writeAuditLog(context, {
+      actionType: "escalate_avatar",
+      objectType: "avatar_profile",
+      objectId: input.avatarProfileId,
+      result: "succeeded",
+      notes: input.reason
+    });
+  }
+
+  return sessionId;
+}
+
+export async function createAvatarProfile(context: AppContext, input: AvatarProfileCreateInput) {
+  await ensureAgentPackExists(context, input.activePackId);
+
+  const avatarId = createId("avatar");
+  const timestamp = nowIso();
+  await context.db.insert(avatarProfiles).values({
+    id: avatarId,
+    title: input.title,
+    activePackId: input.activePackId,
+    intro: input.intro,
+    toneRulesJson: JSON.stringify(input.toneRules),
+    forbiddenTopicsJson: JSON.stringify(input.forbiddenTopics),
+    escalationRulesJson: JSON.stringify(input.escalationRules),
+    status: input.status,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_avatar_profile",
+    objectType: "avatar_profile",
+    objectId: avatarId,
+    result: "succeeded",
+    notes: input.title
+  });
+
+  return {
+    avatarId,
+    auditId
+  };
+}
+
+export async function listAvatarProfiles(context: AppContext, limit = 80) {
+  const rows = await context.db.query.avatarProfiles.findMany({
+    orderBy: [desc(avatarProfiles.updatedAt)],
+    limit
+  });
+  return rows.map(parseProfile);
+}
+
+export async function getAvatarProfile(context: AppContext, avatarId: string) {
+  const row = await context.db.query.avatarProfiles.findFirst({
+    where: eq(avatarProfiles.id, avatarId)
+  });
+  return row ? parseProfile(row) : null;
+}
+
+export async function updateAvatarProfile(context: AppContext, avatarId: string, input: AvatarProfileUpdateInput) {
+  const row = await context.db.query.avatarProfiles.findFirst({
+    where: eq(avatarProfiles.id, avatarId)
+  });
+
+  if (!row) {
+    throw new Error("Avatar profile not found.");
+  }
+
+  if (input.activePackId) {
+    await ensureAgentPackExists(context, input.activePackId);
+  }
+
+  await context.db
+    .update(avatarProfiles)
+    .set({
+      activePackId: input.activePackId ?? row.activePackId,
+      intro: input.intro ?? row.intro,
+      toneRulesJson: JSON.stringify(input.toneRules ?? parseJsonArray<string>(row.toneRulesJson)),
+      forbiddenTopicsJson: JSON.stringify(input.forbiddenTopics ?? parseJsonArray<string>(row.forbiddenTopicsJson)),
+      escalationRulesJson: JSON.stringify(input.escalationRules ?? parseJsonObject(row.escalationRulesJson, defaultEscalationRules)),
+      updatedAt: nowIso()
+    })
+    .where(eq(avatarProfiles.id, avatarId));
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "update_avatar_profile",
+    objectType: "avatar_profile",
+    objectId: avatarId,
+    result: "succeeded"
+  });
+
+  return {
+    avatarId,
+    auditId
+  };
+}
+
+export async function setAvatarStatus(context: AppContext, avatarId: string, status: AvatarStatus) {
+  const row = await context.db.query.avatarProfiles.findFirst({
+    where: eq(avatarProfiles.id, avatarId)
+  });
+
+  if (!row) {
+    throw new Error("Avatar profile not found.");
+  }
+
+  await context.db
+    .update(avatarProfiles)
+    .set({
+      status,
+      updatedAt: nowIso()
+    })
+    .where(eq(avatarProfiles.id, avatarId));
+
+  const auditId = await writeAuditLog(context, {
+    actionType: status === "paused" ? "pause_avatar" : "activate_avatar",
+    objectType: "avatar_profile",
+    objectId: avatarId,
+    result: "succeeded"
+  });
+
+  return {
+    avatarId,
+    auditId
+  };
+}
+
+export async function listAvatarSimulationSessions(context: AppContext, avatarProfileId: string, limit = 40) {
+  const rows = await context.db.query.avatarSimulationSessions.findMany({
+    where: eq(avatarSimulationSessions.avatarProfileId, avatarProfileId),
+    orderBy: [desc(avatarSimulationSessions.createdAt)],
+    limit
+  });
+  return rows.map(parseSimulationSession);
+}
+
+export async function simulateAvatar(context: AppContext, avatarId: string, input: AvatarSimulationInput) {
+  const profile = await getAvatarProfile(context, avatarId);
+  if (!profile) {
+    throw new Error("Avatar profile not found.");
+  }
+
+  if (profile.status === "paused") {
+    const answerMd = "This avatar is paused and cannot respond until it is reactivated.";
+    const sessionId = await createSimulationSession(context, {
+      avatarProfileId: profile.id,
+      question: input.question,
+      resultStatus: "refused",
+      answerMd,
+      citations: [],
+      reason: "avatar_paused"
+    });
+    return {
+      sessionId,
+      resultStatus: "refused" as const,
+      answerMd,
+      citations: [],
+      reason: "avatar_paused"
+    };
+  }
+
+  const pack = await getAgentPackSnapshot(context, profile.activePackId);
+  if (!pack) {
+    const answerMd = "The active agent pack could not be loaded. Escalate to the owner.";
+    const sessionId = await createSimulationSession(context, {
+      avatarProfileId: profile.id,
+      question: input.question,
+      resultStatus: "escalated",
+      answerMd,
+      citations: [],
+      reason: "missing_active_pack"
+    });
+    return {
+      sessionId,
+      resultStatus: "escalated" as const,
+      answerMd,
+      citations: [],
+      reason: "missing_active_pack"
+    };
+  }
+
+  const scopedEvidence = await resolvePackEvidence(context, pack);
+  const classification = classifyQuestion(profile, scopedEvidence, input.question);
+
+  if (classification.kind !== "answered") {
+    const answerMd =
+      classification.kind === "escalated"
+        ? "This request falls outside the avatar’s safe authority and should be escalated to the owner."
+        : "This avatar cannot answer that request within its current rules and evidence boundary.";
+    const sessionId = await createSimulationSession(context, {
+      avatarProfileId: profile.id,
+      question: input.question,
+      resultStatus: classification.kind,
+      answerMd,
+      citations: [],
+      reason: classification.reason
+    });
+
+    return {
+      sessionId,
+      resultStatus: classification.kind,
+      answerMd,
+      citations: [],
+      reason: classification.reason
+    };
+  }
+
+  if (!context.provider.isConfigured) {
+    const answerMd = "The avatar cannot generate a governed reply because no model provider is configured. Escalate to the owner.";
+    const sessionId = await createSimulationSession(context, {
+      avatarProfileId: profile.id,
+      question: input.question,
+      resultStatus: "escalated",
+      answerMd,
+      citations: [],
+      reason: "provider_unavailable"
+    });
+    return {
+      sessionId,
+      resultStatus: "escalated" as const,
+      answerMd,
+      citations: [],
+      reason: "provider_unavailable"
+    };
+  }
+
+  const generated = await context.provider.generateAvatarReply({
+    avatarTitle: profile.title,
+    intro: profile.intro,
+    toneRules: profile.toneRules,
+    question: input.question,
+    evidence: classification.evidence.map((entry) => ({
+      refId: entry.id,
+      title: entry.title,
+      text: entry.text
+    }))
+  });
+
+  const allowedRefIds = new Set(classification.evidence.map((entry) => entry.id));
+  const citations = generated.citations
+    .filter((entry) => entry.kind === "wiki_node" && allowedRefIds.has(entry.refId))
+    .map((entry) => ({
+      refId: entry.refId,
+      kind: "wiki_node" as const,
+      excerpt: entry.excerpt,
+      score: entry.score
+    }));
+
+  const sessionId = await createSimulationSession(context, {
+    avatarProfileId: profile.id,
+    question: input.question,
+    resultStatus: "answered",
+    answerMd: generated.answerMd,
+    citations,
+    reason: ""
+  });
+
+  return {
+    sessionId,
+    resultStatus: "answered" as const,
+    answerMd: generated.answerMd,
+    citations,
+    reason: ""
+  };
+}

--- a/apps/web/src/server/tests/audit.test.ts
+++ b/apps/web/src/server/tests/audit.test.ts
@@ -17,6 +17,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("audit service", () => {

--- a/apps/web/src/server/tests/avatars.test.ts
+++ b/apps/web/src/server/tests/avatars.test.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { postcards, visaBundles, wikiNodes } from "@/server/db/schema";
+import { createId } from "@/server/services/common";
+import { createAgentPackSnapshot, getAgentPackSnapshot } from "@/server/services/agent-packs";
+import {
+  createAvatarProfile,
+  getAvatarProfile,
+  listAvatarSimulationSessions,
+  setAvatarStatus,
+  simulateAvatar,
+  updateAvatarProfile
+} from "@/server/services/avatars";
+
+import { describe, expect, it } from "vitest";
+
+class FakeProvider implements ModelProvider {
+  readonly isConfigured = true;
+  async extractStructured() { return { summary: "", keyClaims: [], concepts: [], themes: [], tags: [] }; }
+  async summarizeAndLink() { return { nodes: [], relationHints: [] }; }
+  async embedText() { return []; }
+  async transcribeAudio() { return ""; }
+  async generateAnswer() { return { answerMd: "", citations: [] }; }
+  async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
+  async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
+    return {
+      answerMd: `Governed answer: ${input.evidence[0]?.text ?? ""}`,
+      citations: input.evidence.slice(0, 2).map((entry, index) => ({
+        refId: entry.refId,
+        kind: "wiki_node" as const,
+        excerpt: entry.text.slice(0, 80),
+        score: 0.9 - index * 0.1
+      }))
+    };
+  }
+}
+
+async function createTestContext(prefix: string) {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const dataDir = path.join(tempRoot, "data");
+  await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+  return createAppContext({
+    dataDir,
+    databasePath: path.join(dataDir, "test.sqlite"),
+    provider: new FakeProvider()
+  });
+}
+
+async function seedPackFixtures(context: ReturnType<typeof createAppContext>) {
+  const nodeId = createId("node");
+  const nodeTwoId = createId("node");
+  const cardId = createId("card");
+  const visaId = createId("visa");
+  const timestamp = new Date().toISOString();
+
+  await context.db.insert(wikiNodes).values([
+    {
+      id: nodeId,
+      nodeType: "summary",
+      title: "Knowledge Passport",
+      summary: "A knowledge passport compiles private material into reusable, governed context.",
+      bodyMd: "The knowledge passport is for governed context and evidence-backed expression.",
+      status: "accepted",
+      sourceIdsJson: JSON.stringify([]),
+      tagsJson: JSON.stringify(["passport", "knowledge"]),
+      projectKey: "atlas",
+      privacyLevel: "L1_LOCAL_AI",
+      embeddingJson: null,
+      updatedAt: timestamp,
+      createdAt: timestamp
+    },
+    {
+      id: nodeTwoId,
+      nodeType: "summary",
+      title: "Pricing Strategy",
+      summary: "Private pricing decisions should not be delegated.",
+      bodyMd: "Pricing should remain a forbidden topic for delegated agents.",
+      status: "accepted",
+      sourceIdsJson: JSON.stringify([]),
+      tagsJson: JSON.stringify(["pricing"]),
+      projectKey: "atlas",
+      privacyLevel: "L1_LOCAL_AI",
+      embeddingJson: null,
+      updatedAt: timestamp,
+      createdAt: timestamp
+    }
+  ]);
+
+  await context.db.insert(postcards).values({
+    id: cardId,
+    cardType: "knowledge",
+    title: "Passport Card",
+    claim: "Knowledge passports package evidence-based context.",
+    evidenceSummary: "Grounded in accepted node summaries.",
+    userView: "Use it for controlled sharing.",
+    relatedNodeIdsJson: JSON.stringify([nodeId]),
+    relatedSourceIdsJson: JSON.stringify([]),
+    privacyLevel: "L1_LOCAL_AI",
+    version: 1,
+    updatedAt: timestamp,
+    createdAt: timestamp
+  });
+
+  await context.db.insert(visaBundles).values({
+    id: visaId,
+    title: "Visa Source",
+    audienceLabel: "Partner",
+    passportId: null,
+    description: "",
+    purpose: "",
+    humanMarkdown: "# Visa",
+    machineManifestJson: JSON.stringify({ title: "Visa" }),
+    includeNodeIdsJson: JSON.stringify([nodeId]),
+    includePostcardIdsJson: JSON.stringify([cardId]),
+    privacyFloor: "L1_LOCAL_AI",
+    redactionJson: JSON.stringify({}),
+    allowMachineDownload: 1,
+    expiresAt: null,
+    status: "active",
+    tokenHash: "hash",
+    lastAccessedAt: null,
+    lastMachineAccessedAt: null,
+    accessCount: 0,
+    maxAccessCount: null,
+    machineDownloadCount: 0,
+    maxMachineDownloads: null,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  return { nodeId, nodeTwoId, cardId, visaId };
+}
+
+describe("avatar governance", () => {
+  it("creates agent packs from visas and explicit selections", async () => {
+    const context = await createTestContext("akp-avatar-pack-");
+    const fixture = await seedPackFixtures(context);
+
+    const fromVisa = await createAgentPackSnapshot(context, {
+      title: "Pack From Visa",
+      visaId: fixture.visaId,
+      passportId: undefined,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+    const visaPack = await getAgentPackSnapshot(context, fromVisa.packId);
+    expect(visaPack?.sourceVisaId).toBe(fixture.visaId);
+    expect(visaPack?.includeNodeIds).toEqual([fixture.nodeId]);
+    expect(visaPack?.includePostcardIds).toEqual([fixture.cardId]);
+
+    const explicit = await createAgentPackSnapshot(context, {
+      title: "Explicit Pack",
+      visaId: undefined,
+      passportId: undefined,
+      includeNodeIds: [fixture.nodeTwoId],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+    const explicitPack = await getAgentPackSnapshot(context, explicit.packId);
+    expect(explicitPack?.includeNodeIds).toEqual([fixture.nodeTwoId]);
+    expect(explicitPack?.includePostcardIds).toEqual([]);
+  });
+
+  it("creates and updates avatar profiles", async () => {
+    const context = await createTestContext("akp-avatar-profile-");
+    const fixture = await seedPackFixtures(context);
+    const pack = await createAgentPackSnapshot(context, {
+      title: "Profile Pack",
+      visaId: fixture.visaId,
+      passportId: undefined,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+
+    const created = await createAvatarProfile(context, {
+      title: "Assistant Avatar",
+      activePackId: pack.packId,
+      intro: "You speak as a careful assistant.",
+      toneRules: ["calm", "evidence-first"],
+      forbiddenTopics: ["pricing"],
+      escalationRules: {
+        escalateOnForbiddenTopic: true,
+        escalateOnInsufficientEvidence: true,
+        escalateOnOutOfScope: true
+      },
+      status: "active"
+    });
+
+    let avatar = await getAvatarProfile(context, created.avatarId);
+    expect(avatar?.status).toBe("active");
+    expect(avatar?.forbiddenTopics).toContain("pricing");
+
+    await updateAvatarProfile(context, created.avatarId, {
+      intro: "Updated intro",
+      toneRules: ["concise"],
+      forbiddenTopics: ["pricing", "clients"]
+    });
+
+    avatar = await getAvatarProfile(context, created.avatarId);
+    expect(avatar?.intro).toBe("Updated intro");
+    expect(avatar?.toneRules).toEqual(["concise"]);
+    expect(avatar?.forbiddenTopics).toContain("clients");
+  });
+
+  it("simulates answered, refused, and escalated sessions with scoped citations", async () => {
+    const context = await createTestContext("akp-avatar-sim-");
+    const fixture = await seedPackFixtures(context);
+    const pack = await createAgentPackSnapshot(context, {
+      title: "Simulation Pack",
+      visaId: fixture.visaId,
+      passportId: undefined,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+
+    const avatarCreated = await createAvatarProfile(context, {
+      title: "Governed Avatar",
+      activePackId: pack.packId,
+      intro: "You are a governed avatar.",
+      toneRules: ["calm", "evidence-first"],
+      forbiddenTopics: ["pricing"],
+      escalationRules: {
+        escalateOnForbiddenTopic: true,
+        escalateOnInsufficientEvidence: false,
+        escalateOnOutOfScope: true
+      },
+      status: "active"
+    });
+
+    const answered = await simulateAvatar(context, avatarCreated.avatarId, {
+      question: "How does a knowledge passport help with governed context?"
+    });
+    expect(answered.resultStatus).toBe("answered");
+    expect(answered.citations.length).toBeGreaterThan(0);
+    expect(answered.citations.every((citation) => citation.refId === fixture.nodeId)).toBe(true);
+
+    const refused = await simulateAvatar(context, avatarCreated.avatarId, {
+      question: "Tell me about pricing strategy."
+    });
+    expect(refused.resultStatus).toBe("escalated");
+    expect(refused.reason).toContain("forbidden_topic");
+
+    await updateAvatarProfile(context, avatarCreated.avatarId, {
+      forbiddenTopics: [],
+      escalationRules: {
+        escalateOnForbiddenTopic: true,
+        escalateOnInsufficientEvidence: false,
+        escalateOnOutOfScope: false
+      }
+    });
+
+    const outOfScope = await simulateAvatar(context, avatarCreated.avatarId, {
+      question: "What is the best restaurant in Sydney?"
+    });
+    expect(outOfScope.resultStatus).toBe("refused");
+    expect(outOfScope.reason).toBe("out_of_scope");
+
+    await setAvatarStatus(context, avatarCreated.avatarId, "paused");
+    const paused = await simulateAvatar(context, avatarCreated.avatarId, {
+      question: "Can you answer now?"
+    });
+    expect(paused.resultStatus).toBe("refused");
+    expect(paused.reason).toBe("avatar_paused");
+
+    const sessions = await listAvatarSimulationSessions(context, avatarCreated.avatarId, 20);
+    expect(sessions.length).toBe(4);
+    expect(sessions.some((session) => session.resultStatus === "answered")).toBe(true);
+    expect(sessions.some((session) => session.resultStatus === "escalated")).toBe(true);
+    expect(sessions.some((session) => session.reason === "avatar_paused")).toBe(true);
+  });
+});

--- a/apps/web/src/server/tests/claims.test.ts
+++ b/apps/web/src/server/tests/claims.test.ts
@@ -32,6 +32,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("claim service", () => {

--- a/apps/web/src/server/tests/compilation-runs.test.ts
+++ b/apps/web/src/server/tests/compilation-runs.test.ts
@@ -32,6 +32,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("compilation runs", () => {

--- a/apps/web/src/server/tests/fragments.test.ts
+++ b/apps/web/src/server/tests/fragments.test.ts
@@ -18,6 +18,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("fragment service", () => {

--- a/apps/web/src/server/tests/grants.test.ts
+++ b/apps/web/src/server/tests/grants.test.ts
@@ -17,6 +17,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("grant service", () => {

--- a/apps/web/src/server/tests/health.test.ts
+++ b/apps/web/src/server/tests/health.test.ts
@@ -19,6 +19,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("health report", () => {

--- a/apps/web/src/server/tests/mvp.test.ts
+++ b/apps/web/src/server/tests/mvp.test.ts
@@ -90,6 +90,18 @@ class FakeProvider implements ModelProvider {
       }
     };
   }
+
+  async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
+    return {
+      answerMd: `Avatar reply grounded in pack evidence: ${input.evidence[0]?.text ?? ""}`,
+      citations: input.evidence.slice(0, 2).map((entry, index) => ({
+        refId: entry.refId,
+        kind: "wiki_node" as const,
+        excerpt: entry.text.slice(0, 80),
+        score: 0.9 - index * 0.1
+      }))
+    };
+  }
 }
 
 describe("knowledge passport MVP flow", () => {

--- a/apps/web/src/server/tests/visas.test.ts
+++ b/apps/web/src/server/tests/visas.test.ts
@@ -36,6 +36,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 async function createTestContext(prefix: string) {

--- a/apps/web/src/server/tests/visuals.test.ts
+++ b/apps/web/src/server/tests/visuals.test.ts
@@ -18,6 +18,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
 describe("visual overview", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -112,6 +112,17 @@ export const visaFeedbackStatuses = [
   "ignored"
 ] as const;
 
+export const avatarStatuses = [
+  "active",
+  "paused"
+] as const;
+
+export const avatarSimulationStatuses = [
+  "answered",
+  "refused",
+  "escalated"
+] as const;
+
 export const sourceTypeSchema = z.enum(sourceTypes);
 export const privacyLevelSchema = z.enum(privacyLevels);
 export const sourceStatusSchema = z.enum(sourceStatuses);
@@ -128,6 +139,8 @@ export const visaAccessTypeSchema = z.enum(visaAccessTypes);
 export const visaAccessResultSchema = z.enum(visaAccessResults);
 export const visaFeedbackTypeSchema = z.enum(visaFeedbackTypes);
 export const visaFeedbackStatusSchema = z.enum(visaFeedbackStatuses);
+export const avatarStatusSchema = z.enum(avatarStatuses);
+export const avatarSimulationStatusSchema = z.enum(avatarSimulationStatuses);
 
 export const importPayloadSchema = z.object({
   type: sourceTypeSchema,
@@ -217,6 +230,51 @@ export const visaFeedbackReviewSchema = z.object({
   status: visaFeedbackStatusSchema
 });
 
+export const agentPackCreateSchema = z.object({
+  title: z.string().min(1),
+  passportId: z.string().optional(),
+  visaId: z.string().optional(),
+  includeNodeIds: z.array(z.string()).default([]),
+  includePostcardIds: z.array(z.string()).default([]),
+  privacyFloor: privacyLevelSchema.default("L1_LOCAL_AI")
+});
+
+export const avatarEscalationRulesSchema = z.object({
+  escalateOnForbiddenTopic: z.boolean().default(true),
+  escalateOnInsufficientEvidence: z.boolean().default(true),
+  escalateOnOutOfScope: z.boolean().default(true)
+});
+
+export const avatarProfileCreateSchema = z.object({
+  title: z.string().min(1),
+  activePackId: z.string().min(1),
+  intro: z.string().default(""),
+  toneRules: z.array(z.string()).default([]),
+  forbiddenTopics: z.array(z.string()).default([]),
+  escalationRules: avatarEscalationRulesSchema.default({
+    escalateOnForbiddenTopic: true,
+    escalateOnInsufficientEvidence: true,
+    escalateOnOutOfScope: true
+  }),
+  status: avatarStatusSchema.default("active")
+});
+
+export const avatarProfileUpdateSchema = z.object({
+  activePackId: z.string().min(1).optional(),
+  intro: z.string().optional(),
+  toneRules: z.array(z.string()).optional(),
+  forbiddenTopics: z.array(z.string()).optional(),
+  escalationRules: avatarEscalationRulesSchema.optional()
+});
+
+export const avatarSimulationInputSchema = z.object({
+  question: z.string().min(1)
+});
+
+export const avatarStatusUpdateSchema = z.object({
+  status: avatarStatusSchema
+});
+
 export const backupCreateSchema = z.object({
   note: z.string().default("manual_backup")
 });
@@ -242,6 +300,8 @@ export type VisaAccessType = z.infer<typeof visaAccessTypeSchema>;
 export type VisaAccessResult = z.infer<typeof visaAccessResultSchema>;
 export type VisaFeedbackType = z.infer<typeof visaFeedbackTypeSchema>;
 export type VisaFeedbackStatus = z.infer<typeof visaFeedbackStatusSchema>;
+export type AvatarStatus = z.infer<typeof avatarStatusSchema>;
+export type AvatarSimulationStatus = z.infer<typeof avatarSimulationStatusSchema>;
 export type ImportPayload = z.infer<typeof importPayloadSchema>;
 export type ResearchQuery = z.infer<typeof researchQuerySchema>;
 export type OutputCreateInput = z.infer<typeof outputCreateSchema>;
@@ -251,6 +311,11 @@ export type VisaRedactionConfig = z.infer<typeof visaRedactionSchema>;
 export type VisaBundleCreateInput = z.infer<typeof visaBundleCreateSchema>;
 export type VisaFeedbackCreateInput = z.infer<typeof visaFeedbackCreateSchema>;
 export type VisaFeedbackReviewInput = z.infer<typeof visaFeedbackReviewSchema>;
+export type AgentPackCreateInput = z.infer<typeof agentPackCreateSchema>;
+export type AvatarEscalationRules = z.infer<typeof avatarEscalationRulesSchema>;
+export type AvatarProfileCreateInput = z.infer<typeof avatarProfileCreateSchema>;
+export type AvatarProfileUpdateInput = z.infer<typeof avatarProfileUpdateSchema>;
+export type AvatarSimulationInput = z.infer<typeof avatarSimulationInputSchema>;
 export type BackupCreateInput = z.infer<typeof backupCreateSchema>;
 export type BackupRestoreInput = z.infer<typeof backupRestoreSchema>;
 
@@ -307,4 +372,51 @@ export type VisaFeedbackQueueItem = {
   status: VisaFeedbackStatus;
   createdAt: string;
   updatedAt: string;
+};
+
+export type AgentPackSummary = {
+  id: string;
+  title: string;
+  sourcePassportId: string | null;
+  sourceVisaId: string | null;
+  includeNodeIds: string[];
+  includePostcardIds: string[];
+  privacyFloor: PrivacyLevel;
+  createdAt: string;
+};
+
+export type AgentPackSnapshot = AgentPackSummary & {
+  humanMarkdown: string;
+  machineManifest: Record<string, unknown>;
+};
+
+export type AvatarProfileSummary = {
+  id: string;
+  title: string;
+  activePackId: string;
+  intro: string;
+  toneRules: string[];
+  forbiddenTopics: string[];
+  escalationRules: AvatarEscalationRules;
+  status: AvatarStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AvatarSimulationCitation = {
+  refId: string;
+  kind: "wiki_node";
+  excerpt: string;
+  score: number;
+};
+
+export type AvatarSimulationSession = {
+  id: string;
+  avatarProfileId: string;
+  question: string;
+  resultStatus: AvatarSimulationStatus;
+  answerMd: string;
+  citations: AvatarSimulationCitation[];
+  reason: string;
+  createdAt: string;
 };


### PR DESCRIPTION
## Summary
- add agent pack snapshots, avatar profiles, and governed simulation sessions
- add internal avatar console pages and APIs for pack/profile management and simulation
- add governed avatar reply support, audit visibility, and V2 governance tests

## Validation
- npm run verify
