### PR TITLE
Add cross-AI agent pack export packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The public repository currently implements a single-user Web system with this en
 - Postcard generation, passport snapshot generation, and backup zip exports
 - Visa bundle generation, managed secret-link sharing, machine-manifest downloads, and lightweight external flowback
 - Agent pack snapshots, avatar profiles, and governed internal-only simulation sessions
+- Cross-AI zip bundle exports for agent packs with manifests, counts, and checksum tracking
 - Fragment inspection, health diagnostics, audit history, and visual knowledge summaries
 - Next.js Web UI and a local worker
 
@@ -41,6 +42,7 @@ The current app shell includes:
 - `Passport & Backup`
 - `Visas`
 - `Avatars`
+- `Exports`
 - `Fragments`
 
 ## Architecture

--- a/apps/web/src/app/api/exports/[id]/download/route.ts
+++ b/apps/web/src/app/api/exports/[id]/download/route.ts
@@ -1,0 +1,26 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import path from "node:path";
+
+import { getAppContext } from "@/server/context";
+import { recordExportDownload } from "@/server/services/exports";
+
+export async function GET(_: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+
+  try {
+    const exportPackage = await recordExportDownload(getAppContext(), params.id);
+    return new NextResponse(await (await import("node:fs/promises")).readFile(exportPackage.filePath), {
+      headers: {
+        "content-type": "application/zip",
+        "content-disposition": `attachment; filename="${path.basename(exportPackage.filePath)}"`
+      }
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Export package not found" },
+      { status: 404 }
+    );
+  }
+}

--- a/apps/web/src/app/api/exports/[id]/route.ts
+++ b/apps/web/src/app/api/exports/[id]/route.ts
@@ -1,0 +1,17 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { getAppContext } from "@/server/context";
+import { getExportPackage } from "@/server/services/exports";
+
+export async function GET(_: Request, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  const exportPackage = await getExportPackage(getAppContext(), params.id);
+
+  if (!exportPackage) {
+    return NextResponse.json({ error: "Export package not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(exportPackage);
+}

--- a/apps/web/src/app/api/exports/agent-packs/route.ts
+++ b/apps/web/src/app/api/exports/agent-packs/route.ts
@@ -1,0 +1,21 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { agentPackExportCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createAgentPackExportPackage } from "@/server/services/exports";
+
+export async function POST(request: Request) {
+  try {
+    const payload = agentPackExportCreateSchema.parse(await request.json());
+    const result = await createAgentPackExportPackage(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Agent pack export failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/exports/route.ts
+++ b/apps/web/src/app/api/exports/route.ts
@@ -1,0 +1,11 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { getAppContext } from "@/server/context";
+import { listExportPackages } from "@/server/services/exports";
+
+export async function GET() {
+  const exports = await listExportPackages(getAppContext(), 80);
+  return NextResponse.json({ exports });
+}

--- a/apps/web/src/app/audit/page.tsx
+++ b/apps/web/src/app/audit/page.tsx
@@ -18,7 +18,8 @@ const filterLinks = [
   { label: "Visa Feedback", href: "/audit?objectType=visa_feedback" },
   { label: "Avatar Profiles", href: "/audit?objectType=avatar_profile" },
   { label: "Avatar Sessions", href: "/audit?objectType=avatar_simulation_session" },
-  { label: "Agent Packs", href: "/audit?objectType=agent_pack_snapshot" }
+  { label: "Agent Packs", href: "/audit?objectType=agent_pack_snapshot" },
+  { label: "Export Packages", href: "/audit?objectType=export_package" }
 ];
 
 export default async function AuditPage(props: {

--- a/apps/web/src/app/avatars/[id]/page.tsx
+++ b/apps/web/src/app/avatars/[id]/page.tsx
@@ -99,6 +99,11 @@ export default async function AvatarDetailPage(props: { params: Promise<{ id: st
               </div>
             </div>
             <AvatarStatusToggle avatarId={avatar.id} status={avatar.status} />
+            <div>
+              <Link href={`/exports?agentPackId=${avatar.activePackId}&avatarProfileId=${avatar.id}`} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+                Export Cross-AI Bundle
+              </Link>
+            </div>
           </div>
         </SectionCard>
 

--- a/apps/web/src/app/avatars/page.tsx
+++ b/apps/web/src/app/avatars/page.tsx
@@ -68,6 +68,11 @@ export default async function AvatarsPage() {
                   <span className="rounded-full bg-black/5 px-3 py-1">cards {pack.includePostcardIds.length}</span>
                   <span className="rounded-full bg-black/5 px-3 py-1">{pack.createdAt}</span>
                 </div>
+                <div className="mt-4">
+                  <Link href={`/exports?agentPackId=${pack.id}`} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+                    Export Pack
+                  </Link>
+                </div>
               </article>
             ))}
             {packs.length === 0 ? <p className="text-sm text-[var(--muted)]">No agent packs exist yet.</p> : null}

--- a/apps/web/src/app/exports/page.tsx
+++ b/apps/web/src/app/exports/page.tsx
@@ -1,0 +1,81 @@
+export const dynamic = "force-dynamic";
+
+import { ExportPackageActions } from "@/components/export-package-actions";
+import { ExportPackageForm } from "@/components/export-package-form";
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { listAgentPacks } from "@/server/services/agent-packs";
+import { listAvatarProfiles } from "@/server/services/avatars";
+import { listExportPackages } from "@/server/services/exports";
+
+export default async function ExportsPage(props: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const searchParams = props.searchParams ? await props.searchParams : {};
+  const defaultPackId = typeof searchParams.agentPackId === "string" ? searchParams.agentPackId : undefined;
+  const defaultAvatarId = typeof searchParams.avatarProfileId === "string" ? searchParams.avatarProfileId : undefined;
+
+  const context = getAppContext();
+  const [packs, avatars, exports] = await Promise.all([
+    listAgentPacks(context, 80),
+    listAvatarProfiles(context, 80),
+    listExportPackages(context, 80)
+  ]);
+
+  const latest = exports[0];
+
+  return (
+    <PageShell currentPath="/exports" title="Exports" subtitle="Package governed agent packs into portable cross-AI zip bundles with stable manifests and checksums">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Export Packages" value={exports.length} />
+        <StatTile label="Latest Export" value={latest?.title ?? "none"} hint={latest?.createdAt ?? "No export packages yet"} />
+        <StatTile label="Tracked Packs" value={packs.length} />
+        <StatTile label="Avatar Contexts" value={avatars.length} />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Create Cross-AI Bundle" description="Export an agent pack as a versioned zip bundle with manifest, pack snapshot, evidence-level node/card data, and optional avatar profile context.">
+          <ExportPackageForm
+            packs={packs.map((pack) => ({ id: pack.id, title: pack.title }))}
+            avatars={avatars.map((avatar) => ({ id: avatar.id, title: avatar.title, activePackId: avatar.activePackId }))}
+            defaultPackId={defaultPackId}
+            defaultAvatarId={defaultAvatarId}
+          />
+          {packs.length === 0 ? <p className="mt-4 text-sm text-[var(--muted)]">Create an agent pack first. Export packages are pack-based in this phase.</p> : null}
+        </SectionCard>
+
+        <SectionCard title="Export Registry" description="Internal-only bundle records with checksums, counts, and download actions.">
+          <div className="space-y-4">
+            {exports.map((entry) => (
+              <article key={entry.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{entry.title}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{entry.id}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusBadge>{entry.objectType}</StatusBadge>
+                    <StatusBadge>{entry.status}</StatusBadge>
+                  </div>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">{entry.formatVersion}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">nodes {entry.counts.nodeCount}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">cards {entry.counts.postcardCount}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">citations {entry.counts.citationCount}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">sha {entry.bundleSha256.slice(0, 12)}...</span>
+                </div>
+                <p className="mt-3 text-sm text-[var(--muted)]">{entry.createdAt}</p>
+                <div className="mt-4">
+                  <ExportPackageActions exportId={entry.id} />
+                </div>
+              </article>
+            ))}
+            {exports.length === 0 ? <p className="text-sm text-[var(--muted)]">No export packages exist yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/components/export-package-actions.tsx
+++ b/apps/web/src/components/export-package-actions.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+export function ExportPackageActions(props: {
+  exportId: string;
+}) {
+  return (
+    <div className="flex flex-wrap gap-3 text-sm">
+      <a className="rounded-full border border-[var(--line)] px-4 py-2" href={`/api/exports/${props.exportId}/download`}>
+        Download Bundle
+      </a>
+      <a className="rounded-full border border-[var(--line)] px-4 py-2" href={`/api/exports/${props.exportId}`}>
+        View Manifest JSON
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/export-package-form.tsx
+++ b/apps/web/src/components/export-package-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function ExportPackageForm(props: {
+  packs: Array<{ id: string; title: string }>;
+  avatars: Array<{ id: string; title: string; activePackId: string }>;
+  defaultPackId?: string;
+  defaultAvatarId?: string;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+
+        startTransition(async () => {
+          const response = await fetch("/api/exports/agent-packs", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              agentPackId: formData.get("agentPackId"),
+              avatarProfileId: formData.get("avatarProfileId") || undefined,
+              includeAvatarProfile: formData.get("includeAvatarProfile") === "on"
+            })
+          });
+
+          const payload = await response.json();
+          if (response.ok) {
+            setMessage(`Export created: ${payload.exportId}`);
+            form.reset();
+            router.refresh();
+            return;
+          }
+          setMessage(payload.error ?? "Export creation failed");
+        });
+      }}
+    >
+      <label className="space-y-2 text-sm">
+        <span>Agent Pack</span>
+        <select
+          name="agentPackId"
+          required
+          defaultValue={props.defaultPackId ?? props.packs[0]?.id ?? ""}
+          className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3"
+        >
+          {props.packs.map((pack) => (
+            <option key={pack.id} value={pack.id}>
+              {pack.title} · {pack.id}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+        <label className="flex items-center gap-3 text-sm">
+          <input
+            type="checkbox"
+            name="includeAvatarProfile"
+            defaultChecked={Boolean(props.defaultAvatarId)}
+            className="h-4 w-4 rounded border-[var(--line)]"
+          />
+          <span>Attach avatar profile context</span>
+        </label>
+        <label className="mt-4 block space-y-2 text-sm">
+          <span>Avatar Profile</span>
+          <select
+            name="avatarProfileId"
+            defaultValue={props.defaultAvatarId ?? ""}
+            className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3"
+          >
+            <option value="">None</option>
+            {props.avatars.map((avatar) => (
+              <option key={avatar.id} value={avatar.id}>
+                {avatar.title} · {avatar.id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending || props.packs.length === 0} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Exporting..." : "Create Export Package"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Bot, Database, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints, Workflow } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Bot, Database, Download, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints, Workflow } from "lucide-react";
 import clsx from "clsx";
 
 const navigation = [
@@ -14,6 +14,7 @@ const navigation = [
   { href: "/postcards", label: "Postcards", icon: Activity },
   { href: "/visas", label: "Visas", icon: Key },
   { href: "/avatars", label: "Avatars", icon: Bot },
+  { href: "/exports", label: "Exports", icon: Download },
   { href: "/grants", label: "Grants", icon: Key },
   { href: "/compilation-runs", label: "Compilation Runs", icon: Workflow },
   { href: "/health", label: "Health Center", icon: HeartPulse },

--- a/apps/web/src/server/db/init.ts
+++ b/apps/web/src/server/db/init.ts
@@ -259,6 +259,20 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       created_at text not null
     );
 
+    create table if not exists export_packages (
+      id text primary key,
+      object_type text not null,
+      object_id text not null,
+      title text not null,
+      format_version text not null,
+      file_path text not null,
+      manifest_json text not null,
+      bundle_sha256 text not null,
+      status text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+
     create table if not exists research_sessions (
       id text primary key,
       question text not null,

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -237,6 +237,20 @@ export const avatarSimulationSessions = sqliteTable("avatar_simulation_sessions"
   createdAt: text("created_at").notNull()
 });
 
+export const exportPackages = sqliteTable("export_packages", {
+  id: text("id").primaryKey(),
+  objectType: text("object_type").notNull(),
+  objectId: text("object_id").notNull(),
+  title: text("title").notNull(),
+  formatVersion: text("format_version").notNull(),
+  filePath: text("file_path").notNull(),
+  manifestJson: text("manifest_json").notNull(),
+  bundleSha256: text("bundle_sha256").notNull(),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
 export const researchSessions = sqliteTable("research_sessions", {
   id: text("id").primaryKey(),
   question: text("question").notNull(),

--- a/apps/web/src/server/services/exports.ts
+++ b/apps/web/src/server/services/exports.ts
@@ -1,0 +1,327 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import AdmZip from "adm-zip";
+import { desc, eq } from "drizzle-orm";
+
+import type {
+  AgentPackExportCreateInput,
+  ExportPackageSnapshot,
+  ExportPackageSummary
+} from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import {
+  avatarProfiles,
+  exportPackages,
+  postcards,
+  wikiNodes
+} from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { getAgentPackSnapshot } from "./agent-packs";
+import { createId, nowIso, parseJsonArray } from "./common";
+import { getAvatarProfile } from "./avatars";
+
+const FORMAT_VERSION = "agent-pack-export/v1";
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "export";
+}
+
+async function fileSha256(filePath: string) {
+  const buffer = await fs.readFile(filePath);
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+async function resolveExportData(
+  context: AppContext,
+  input: AgentPackExportCreateInput
+) {
+  const pack = await getAgentPackSnapshot(context, input.agentPackId);
+  if (!pack) {
+    throw new Error("Agent pack snapshot not found.");
+  }
+
+  let avatar = null;
+  if (input.includeAvatarProfile) {
+    if (!input.avatarProfileId) {
+      throw new Error("An avatar profile id is required when includeAvatarProfile=true.");
+    }
+    avatar = await getAvatarProfile(context, input.avatarProfileId);
+    if (!avatar) {
+      throw new Error("Avatar profile not found.");
+    }
+    if (avatar.activePackId !== pack.id) {
+      throw new Error("Avatar profile must point at the selected agent pack.");
+    }
+  }
+
+  const nodes = pack.includeNodeIds.length
+    ? await context.db.query.wikiNodes.findMany({
+        where: (table, { inArray }) => inArray(table.id, pack.includeNodeIds)
+      })
+    : [];
+  const cards = pack.includePostcardIds.length
+    ? await context.db.query.postcards.findMany({
+        where: (table, { inArray }) => inArray(table.id, pack.includePostcardIds)
+      })
+    : [];
+
+  const citations = {
+    nodeSourceReferences: nodes.map((node) => ({
+      nodeId: node.id,
+      sourceIds: parseJsonArray<string>(node.sourceIdsJson)
+    })),
+    postcardReferences: cards.map((card) => ({
+      postcardId: card.id,
+      relatedNodeIds: parseJsonArray<string>(card.relatedNodeIdsJson),
+      relatedSourceIds: parseJsonArray<string>(card.relatedSourceIdsJson)
+    }))
+  };
+
+  return {
+    pack,
+    avatar,
+    nodes: nodes.map((node) => ({
+      id: node.id,
+      title: node.title,
+      summary: node.summary,
+      bodyMd: node.bodyMd,
+      projectKey: node.projectKey,
+      tags: parseJsonArray<string>(node.tagsJson)
+    })),
+    postcards: cards.map((card) => ({
+      id: card.id,
+      title: card.title,
+      claim: card.claim,
+      evidenceSummary: card.evidenceSummary,
+      userView: card.userView,
+      cardType: card.cardType,
+      relatedNodeIds: parseJsonArray<string>(card.relatedNodeIdsJson),
+      relatedSourceIds: parseJsonArray<string>(card.relatedSourceIdsJson)
+    })),
+    citations
+  };
+}
+
+function buildManifest(input: {
+  exportId: string;
+  objectId: string;
+  title: string;
+  privacyFloor: string;
+  includeAvatarProfile: boolean;
+  avatarProfileId: string | null;
+  nodeCount: number;
+  postcardCount: number;
+  citationCount: number;
+  fileChecksums: Record<string, string>;
+}) {
+  return {
+    bundleId: input.exportId,
+    formatVersion: FORMAT_VERSION,
+    objectType: "agent_pack_snapshot",
+    objectId: input.objectId,
+    title: input.title,
+    createdAt: nowIso(),
+    privacyFloor: input.privacyFloor,
+    boundaries: {
+      internalOnly: true,
+      liveAgentCapable: false,
+      importSupported: false,
+      evidenceLevel: "node_card"
+    },
+    includes: {
+      avatarProfile: input.includeAvatarProfile,
+      avatarProfileId: input.avatarProfileId
+    },
+    counts: {
+      nodeCount: input.nodeCount,
+      postcardCount: input.postcardCount,
+      citationCount: input.citationCount
+    },
+    checksumMetadata: {
+      algorithm: "sha256",
+      scope: "bundle-entries",
+      files: input.fileChecksums
+    }
+  };
+}
+
+function bufferSha256(buffer: Buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function buildBundleReadme(input: {
+  title: string;
+  packId: string;
+  avatarTitle: string | null;
+  nodeCount: number;
+  postcardCount: number;
+}) {
+  return [
+    `# ${input.title}`,
+    "",
+    `Exported object: agent_pack_snapshot`,
+    `Agent pack id: ${input.packId}`,
+    `Attached avatar profile: ${input.avatarTitle ?? "none"}`,
+    "",
+    `Included nodes: ${input.nodeCount}`,
+    `Included postcards: ${input.postcardCount}`,
+    "",
+    "This bundle is a portable internal export for cross-AI consumption.",
+    "It intentionally excludes raw source fulltext and full fragment corpora."
+  ].join("\n");
+}
+
+export async function createAgentPackExportPackage(context: AppContext, input: AgentPackExportCreateInput) {
+  const resolved = await resolveExportData(context, input);
+  const exportId = createId("export");
+  const fileName = `${slugify(resolved.pack.title)}-${exportId}.zip`;
+  const filePath = path.join(context.paths.exportsDir, fileName);
+
+  await fs.mkdir(context.paths.exportsDir, { recursive: true });
+
+  const agentPackJson = JSON.stringify(resolved.pack, null, 2);
+  const nodesJson = JSON.stringify(resolved.nodes, null, 2);
+  const postcardsJson = JSON.stringify(resolved.postcards, null, 2);
+  const citationsJson = JSON.stringify(resolved.citations, null, 2);
+  const avatarJson = resolved.avatar ? JSON.stringify(resolved.avatar, null, 2) : null;
+  const readme = buildBundleReadme({
+    title: resolved.pack.title,
+    packId: resolved.pack.id,
+    avatarTitle: resolved.avatar?.title ?? null,
+    nodeCount: resolved.nodes.length,
+    postcardCount: resolved.postcards.length
+  });
+
+  const fileChecksums: Record<string, string> = {
+    "README.md": bufferSha256(Buffer.from(readme, "utf8")),
+    "agent-pack.json": bufferSha256(Buffer.from(agentPackJson, "utf8")),
+    "nodes.json": bufferSha256(Buffer.from(nodesJson, "utf8")),
+    "postcards.json": bufferSha256(Buffer.from(postcardsJson, "utf8")),
+    "citations.json": bufferSha256(Buffer.from(citationsJson, "utf8"))
+  };
+  if (avatarJson) {
+    fileChecksums["avatar-profile.json"] = bufferSha256(Buffer.from(avatarJson, "utf8"));
+  }
+
+  const manifest = buildManifest({
+    exportId,
+    objectId: resolved.pack.id,
+    title: resolved.pack.title,
+    privacyFloor: resolved.pack.privacyFloor,
+    includeAvatarProfile: Boolean(resolved.avatar),
+    avatarProfileId: resolved.avatar?.id ?? null,
+    nodeCount: resolved.nodes.length,
+    postcardCount: resolved.postcards.length,
+    citationCount: resolved.citations.nodeSourceReferences.length + resolved.citations.postcardReferences.length,
+    fileChecksums
+  });
+
+  const zip = new AdmZip();
+  zip.addFile("manifest.json", Buffer.from(JSON.stringify(manifest, null, 2), "utf8"));
+  zip.addFile("README.md", Buffer.from(readme, "utf8"));
+  zip.addFile("agent-pack.json", Buffer.from(agentPackJson, "utf8"));
+  zip.addFile("nodes.json", Buffer.from(nodesJson, "utf8"));
+  zip.addFile("postcards.json", Buffer.from(postcardsJson, "utf8"));
+  zip.addFile("citations.json", Buffer.from(citationsJson, "utf8"));
+  if (avatarJson) {
+    zip.addFile("avatar-profile.json", Buffer.from(avatarJson, "utf8"));
+  }
+  zip.writeZip(filePath);
+
+  const bundleSha256 = await fileSha256(filePath);
+  const timestamp = nowIso();
+  await context.db.insert(exportPackages).values({
+    id: exportId,
+    objectType: "agent_pack_snapshot",
+    objectId: resolved.pack.id,
+    title: resolved.pack.title,
+    formatVersion: FORMAT_VERSION,
+    filePath,
+    manifestJson: JSON.stringify(manifest),
+    bundleSha256,
+    status: "succeeded",
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_export_package",
+    objectType: "export_package",
+    objectId: exportId,
+    result: "succeeded",
+    notes: resolved.pack.id
+  });
+
+  return {
+    exportId,
+    auditId
+  };
+}
+
+function parseExportSummary(row: typeof exportPackages.$inferSelect): ExportPackageSummary {
+  const manifest = JSON.parse(row.manifestJson) as { counts?: { nodeCount?: number; postcardCount?: number; citationCount?: number } };
+  return {
+    id: row.id,
+    objectType: "agent_pack_snapshot",
+    objectId: row.objectId,
+    title: row.title,
+    formatVersion: row.formatVersion,
+    filePath: row.filePath,
+    bundleSha256: row.bundleSha256,
+    status: row.status as ExportPackageSummary["status"],
+    counts: {
+      nodeCount: manifest.counts?.nodeCount ?? 0,
+      postcardCount: manifest.counts?.postcardCount ?? 0,
+      citationCount: manifest.counts?.citationCount ?? 0
+    },
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function parseExportSnapshot(row: typeof exportPackages.$inferSelect): ExportPackageSnapshot {
+  return {
+    ...parseExportSummary(row),
+    manifest: JSON.parse(row.manifestJson) as Record<string, unknown>
+  };
+}
+
+export async function listExportPackages(context: AppContext, limit = 80) {
+  const rows = await context.db.query.exportPackages.findMany({
+    orderBy: [desc(exportPackages.createdAt)],
+    limit
+  });
+  return rows.map(parseExportSummary);
+}
+
+export async function getExportPackage(context: AppContext, exportId: string) {
+  const row = await context.db.query.exportPackages.findFirst({
+    where: eq(exportPackages.id, exportId)
+  });
+  return row ? parseExportSnapshot(row) : null;
+}
+
+export async function recordExportDownload(context: AppContext, exportId: string) {
+  const exportPackage = await getExportPackage(context, exportId);
+  if (!exportPackage) {
+    throw new Error("Export package not found.");
+  }
+
+  await writeAuditLog(context, {
+    actionType: "download_export_package",
+    objectType: "export_package",
+    objectId: exportId,
+    result: "succeeded",
+    notes: exportPackage.objectId
+  });
+
+  return exportPackage;
+}

--- a/apps/web/src/server/tests/exports.test.ts
+++ b/apps/web/src/server/tests/exports.test.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import AdmZip from "adm-zip";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { postcards, wikiNodes } from "@/server/db/schema";
+import { createId } from "@/server/services/common";
+import { createAgentPackSnapshot } from "@/server/services/agent-packs";
+import { createAvatarProfile } from "@/server/services/avatars";
+import {
+  createAgentPackExportPackage,
+  getExportPackage,
+  listExportPackages,
+  recordExportDownload
+} from "@/server/services/exports";
+
+import { describe, expect, it } from "vitest";
+
+class StubProvider implements ModelProvider {
+  readonly isConfigured = false;
+  async extractStructured() { return { summary: "", keyClaims: [], concepts: [], themes: [], tags: [] }; }
+  async summarizeAndLink() { return { nodes: [], relationHints: [] }; }
+  async embedText() { return []; }
+  async transcribeAudio() { return ""; }
+  async generateAnswer() { return { answerMd: "", citations: [] }; }
+  async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
+  async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "", citations: [] }; }
+}
+
+async function createTestContext(prefix: string) {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const dataDir = path.join(tempRoot, "data");
+  await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+  return createAppContext({
+    dataDir,
+    databasePath: path.join(dataDir, "test.sqlite"),
+    provider: new StubProvider()
+  });
+}
+
+async function seedExportFixtures(context: ReturnType<typeof createAppContext>) {
+  const nodeId = createId("node");
+  const cardId = createId("card");
+  const timestamp = new Date().toISOString();
+
+  await context.db.insert(wikiNodes).values({
+    id: nodeId,
+    nodeType: "summary",
+    title: "Agent Pack Node",
+    summary: "Node summary",
+    bodyMd: "Node body markdown",
+    status: "accepted",
+    sourceIdsJson: JSON.stringify(["src_alpha"]),
+    tagsJson: JSON.stringify(["agent", "export"]),
+    projectKey: "atlas",
+    privacyLevel: "L1_LOCAL_AI",
+    embeddingJson: null,
+    updatedAt: timestamp,
+    createdAt: timestamp
+  });
+
+  await context.db.insert(postcards).values({
+    id: cardId,
+    cardType: "knowledge",
+    title: "Agent Pack Card",
+    claim: "Cards capture shareable knowledge claims.",
+    evidenceSummary: "Backed by accepted nodes.",
+    userView: "A compact governed expression layer.",
+    relatedNodeIdsJson: JSON.stringify([nodeId]),
+    relatedSourceIdsJson: JSON.stringify(["src_alpha"]),
+    privacyLevel: "L1_LOCAL_AI",
+    version: 1,
+    updatedAt: timestamp,
+    createdAt: timestamp
+  });
+
+  const pack = await createAgentPackSnapshot(context, {
+    title: "Exportable Pack",
+    passportId: undefined,
+    visaId: undefined,
+    includeNodeIds: [nodeId],
+    includePostcardIds: [cardId],
+    privacyFloor: "L1_LOCAL_AI"
+  });
+
+  const avatar = await createAvatarProfile(context, {
+    title: "Export Avatar",
+    activePackId: pack.packId,
+    intro: "You are a governed export avatar.",
+    toneRules: ["calm", "evidence-first"],
+    forbiddenTopics: ["pricing"],
+    escalationRules: {
+      escalateOnForbiddenTopic: true,
+      escalateOnInsufficientEvidence: true,
+      escalateOnOutOfScope: true
+    },
+    status: "active"
+  });
+
+  return {
+    packId: pack.packId,
+    avatarId: avatar.avatarId
+  };
+}
+
+describe("export packages", () => {
+  it("creates a zip bundle from an agent pack and persists the export record", async () => {
+    const context = await createTestContext("akp-export-");
+    const fixture = await seedExportFixtures(context);
+
+    const created = await createAgentPackExportPackage(context, {
+      agentPackId: fixture.packId,
+      avatarProfileId: fixture.avatarId,
+      includeAvatarProfile: true
+    });
+
+    const exportPackage = await getExportPackage(context, created.exportId);
+    expect(exportPackage?.objectType).toBe("agent_pack_snapshot");
+    expect(exportPackage?.objectId).toBe(fixture.packId);
+    expect(exportPackage?.formatVersion).toBe("agent-pack-export/v1");
+
+    const allPackages = await listExportPackages(context, 20);
+    expect(allPackages[0]?.id).toBe(created.exportId);
+    expect(allPackages[0]?.counts.nodeCount).toBe(1);
+    expect(allPackages[0]?.counts.postcardCount).toBe(1);
+    expect(allPackages[0]?.bundleSha256.length).toBeGreaterThan(20);
+  });
+
+  it("writes the expected zip contents without raw source or fragment corpora", async () => {
+    const context = await createTestContext("akp-export-zip-");
+    const fixture = await seedExportFixtures(context);
+
+    const created = await createAgentPackExportPackage(context, {
+      agentPackId: fixture.packId,
+      avatarProfileId: fixture.avatarId,
+      includeAvatarProfile: true
+    });
+
+    const exportPackage = await getExportPackage(context, created.exportId);
+    if (!exportPackage) {
+      throw new Error("Expected export package");
+    }
+
+    const zip = new AdmZip(exportPackage.filePath);
+    const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+
+    expect(entryNames).toEqual([
+      "README.md",
+      "agent-pack.json",
+      "avatar-profile.json",
+      "citations.json",
+      "manifest.json",
+      "nodes.json",
+      "postcards.json"
+    ]);
+
+    const manifest = JSON.parse(zip.readAsText("manifest.json")) as {
+      boundaries: { evidenceLevel: string };
+      counts: { nodeCount: number; postcardCount: number; citationCount: number };
+    };
+    expect(manifest.boundaries.evidenceLevel).toBe("node_card");
+    expect(manifest.counts.nodeCount).toBe(1);
+    expect(manifest.counts.postcardCount).toBe(1);
+
+    const nodesJson = zip.readAsText("nodes.json");
+    expect(nodesJson).toContain("Node body markdown");
+    expect(nodesJson).not.toContain("raw source fulltext");
+    expect(entryNames.some((name) => name.includes("source_fragments"))).toBe(false);
+  });
+
+  it("rejects avatar attachment when the selected profile does not point at the selected pack", async () => {
+    const context = await createTestContext("akp-export-avatar-");
+    const fixture = await seedExportFixtures(context);
+    const otherPack = await createAgentPackSnapshot(context, {
+      title: "Other Pack",
+      passportId: undefined,
+      visaId: undefined,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    }).catch(() => null);
+
+    const fallbackPack = otherPack?.packId ?? fixture.packId;
+    if (fallbackPack === fixture.packId) {
+      const extraNodeId = createId("node");
+      const timestamp = new Date().toISOString();
+      await context.db.insert(wikiNodes).values({
+        id: extraNodeId,
+        nodeType: "summary",
+        title: "Second Node",
+        summary: "Second summary",
+        bodyMd: "Second body",
+        status: "accepted",
+        sourceIdsJson: JSON.stringify([]),
+        tagsJson: JSON.stringify(["second"]),
+        projectKey: "atlas",
+        privacyLevel: "L1_LOCAL_AI",
+        embeddingJson: null,
+        updatedAt: timestamp,
+        createdAt: timestamp
+      });
+      const pack = await createAgentPackSnapshot(context, {
+        title: "Other Pack",
+        passportId: undefined,
+        visaId: undefined,
+        includeNodeIds: [extraNodeId],
+        includePostcardIds: [],
+        privacyFloor: "L1_LOCAL_AI"
+      });
+
+      await expect(
+        createAgentPackExportPackage(context, {
+          agentPackId: pack.packId,
+          avatarProfileId: fixture.avatarId,
+          includeAvatarProfile: true
+        })
+      ).rejects.toThrow("Avatar profile must point at the selected agent pack.");
+      return;
+    }
+
+    await expect(
+      createAgentPackExportPackage(context, {
+        agentPackId: fallbackPack,
+        avatarProfileId: fixture.avatarId,
+        includeAvatarProfile: true
+      })
+    ).rejects.toThrow("Avatar profile must point at the selected agent pack.");
+  });
+
+  it("records audit logs when a bundle is downloaded", async () => {
+    const context = await createTestContext("akp-export-download-");
+    const fixture = await seedExportFixtures(context);
+
+    const created = await createAgentPackExportPackage(context, {
+      agentPackId: fixture.packId,
+      includeAvatarProfile: false
+    });
+
+    const exportPackage = await recordExportDownload(context, created.exportId);
+    expect(exportPackage.id).toBe(created.exportId);
+
+    const auditLogs = await context.db.query.auditLogs.findMany({
+      where: (table, { eq }) => eq(table.objectType, "export_package")
+    });
+    expect(auditLogs.some((entry) => entry.actionType === "create_export_package")).toBe(true);
+    expect(auditLogs.some((entry) => entry.actionType === "download_export_package")).toBe(true);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -123,6 +123,11 @@ export const avatarSimulationStatuses = [
   "escalated"
 ] as const;
 
+export const exportPackageStatuses = [
+  "succeeded",
+  "failed"
+] as const;
+
 export const sourceTypeSchema = z.enum(sourceTypes);
 export const privacyLevelSchema = z.enum(privacyLevels);
 export const sourceStatusSchema = z.enum(sourceStatuses);
@@ -141,6 +146,7 @@ export const visaFeedbackTypeSchema = z.enum(visaFeedbackTypes);
 export const visaFeedbackStatusSchema = z.enum(visaFeedbackStatuses);
 export const avatarStatusSchema = z.enum(avatarStatuses);
 export const avatarSimulationStatusSchema = z.enum(avatarSimulationStatuses);
+export const exportPackageStatusSchema = z.enum(exportPackageStatuses);
 
 export const importPayloadSchema = z.object({
   type: sourceTypeSchema,
@@ -275,6 +281,12 @@ export const avatarStatusUpdateSchema = z.object({
   status: avatarStatusSchema
 });
 
+export const agentPackExportCreateSchema = z.object({
+  agentPackId: z.string().min(1),
+  avatarProfileId: z.string().optional(),
+  includeAvatarProfile: z.boolean().default(false)
+});
+
 export const backupCreateSchema = z.object({
   note: z.string().default("manual_backup")
 });
@@ -302,6 +314,7 @@ export type VisaFeedbackType = z.infer<typeof visaFeedbackTypeSchema>;
 export type VisaFeedbackStatus = z.infer<typeof visaFeedbackStatusSchema>;
 export type AvatarStatus = z.infer<typeof avatarStatusSchema>;
 export type AvatarSimulationStatus = z.infer<typeof avatarSimulationStatusSchema>;
+export type ExportPackageStatus = z.infer<typeof exportPackageStatusSchema>;
 export type ImportPayload = z.infer<typeof importPayloadSchema>;
 export type ResearchQuery = z.infer<typeof researchQuerySchema>;
 export type OutputCreateInput = z.infer<typeof outputCreateSchema>;
@@ -316,6 +329,7 @@ export type AvatarEscalationRules = z.infer<typeof avatarEscalationRulesSchema>;
 export type AvatarProfileCreateInput = z.infer<typeof avatarProfileCreateSchema>;
 export type AvatarProfileUpdateInput = z.infer<typeof avatarProfileUpdateSchema>;
 export type AvatarSimulationInput = z.infer<typeof avatarSimulationInputSchema>;
+export type AgentPackExportCreateInput = z.infer<typeof agentPackExportCreateSchema>;
 export type BackupCreateInput = z.infer<typeof backupCreateSchema>;
 export type BackupRestoreInput = z.infer<typeof backupRestoreSchema>;
 
@@ -419,4 +433,26 @@ export type AvatarSimulationSession = {
   citations: AvatarSimulationCitation[];
   reason: string;
   createdAt: string;
+};
+
+export type ExportPackageSummary = {
+  id: string;
+  objectType: "agent_pack_snapshot";
+  objectId: string;
+  title: string;
+  formatVersion: string;
+  filePath: string;
+  bundleSha256: string;
+  status: ExportPackageStatus;
+  counts: {
+    nodeCount: number;
+    postcardCount: number;
+    citationCount: number;
+  };
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExportPackageSnapshot = ExportPackageSummary & {
+  manifest: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary
- add tracked export packages for agent-pack snapshots
- generate zip bundles with manifests, node/card evidence payloads, and optional avatar context
- add internal export APIs and an /exports workshop with download actions

## Validation
- npm run verify
