### PR TITLE
Add unified object policy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The public repository currently implements a single-user Web system with this en
 - Visa bundle generation, managed secret-link sharing, machine-manifest downloads, and lightweight external flowback
 - Agent pack snapshots, avatar profiles, and governed internal-only simulation sessions
 - Cross-AI zip bundle exports for agent packs with manifests, counts, and checksum tracking
+- Unified object-level policies across passports, visas, agent packs, avatars, and exports
 - Fragment inspection, health diagnostics, audit history, and visual knowledge summaries
 - Next.js Web UI and a local worker
 
@@ -43,6 +44,7 @@ The current app shell includes:
 - `Visas`
 - `Avatars`
 - `Exports`
+- `Policies`
 - `Fragments`
 
 ## Architecture

--- a/apps/web/src/app/api/policies/resolve/route.ts
+++ b/apps/web/src/app/api/policies/resolve/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { objectPolicyObjectTypeSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { resolveObjectPolicy } from "@/server/services/policies";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const objectType = searchParams.get("objectType");
+  const objectId = searchParams.get("objectId");
+
+  if (!objectType || !objectId) {
+    return NextResponse.json({ error: "objectType and objectId are required" }, { status: 400 });
+  }
+
+  try {
+    const parsedObjectType = objectPolicyObjectTypeSchema.parse(objectType);
+    const resolved = await resolveObjectPolicy(getAppContext(), parsedObjectType, objectId);
+    return NextResponse.json({ resolved });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Policy resolution failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/policies/route.ts
+++ b/apps/web/src/app/api/policies/route.ts
@@ -1,0 +1,26 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { objectPolicyUpsertSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { listObjectPolicies, upsertObjectPolicy } from "@/server/services/policies";
+
+export async function GET() {
+  const policies = await listObjectPolicies(getAppContext(), 120);
+  return NextResponse.json({ policies });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = objectPolicyUpsertSchema.parse(await request.json());
+    const policyId = await upsertObjectPolicy(getAppContext(), payload);
+    return NextResponse.json({ policyId }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Policy save failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/audit/page.tsx
+++ b/apps/web/src/app/audit/page.tsx
@@ -19,7 +19,8 @@ const filterLinks = [
   { label: "Avatar Profiles", href: "/audit?objectType=avatar_profile" },
   { label: "Avatar Sessions", href: "/audit?objectType=avatar_simulation_session" },
   { label: "Agent Packs", href: "/audit?objectType=agent_pack_snapshot" },
-  { label: "Export Packages", href: "/audit?objectType=export_package" }
+  { label: "Export Packages", href: "/audit?objectType=export_package" },
+  { label: "Policies", href: "/audit?objectType=object_policy" }
 ];
 
 export default async function AuditPage(props: {

--- a/apps/web/src/app/policies/page.tsx
+++ b/apps/web/src/app/policies/page.tsx
@@ -1,0 +1,104 @@
+export const dynamic = "force-dynamic";
+
+import { PageShell } from "@/components/page-shell";
+import { PolicyForm } from "@/components/policy-form";
+import { SectionCard, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { listAgentPacks } from "@/server/services/agent-packs";
+import { listAvatarProfiles } from "@/server/services/avatars";
+import { listExportPackages } from "@/server/services/exports";
+import { listPassports } from "@/server/services/passports";
+import { listObjectPolicies, resolveObjectPolicy } from "@/server/services/policies";
+import { listVisaBundles } from "@/server/services/visas";
+
+export default async function PoliciesPage() {
+  const context = getAppContext();
+  const [policies, passports, visas, packs, avatars, exports] = await Promise.all([
+    listObjectPolicies(context, 120),
+    listPassports(context),
+    listVisaBundles(context, 20),
+    listAgentPacks(context, 20),
+    listAvatarProfiles(context, 20),
+    listExportPackages(context, 20)
+  ]);
+
+  const previewObjects = [
+    ...passports.slice(0, 3).map((entry) => ({ objectType: "passport_snapshot" as const, objectId: entry.id, title: entry.title })),
+    ...visas.slice(0, 3).map((entry) => ({ objectType: "visa_bundle" as const, objectId: entry.id, title: entry.title })),
+    ...packs.slice(0, 3).map((entry) => ({ objectType: "agent_pack_snapshot" as const, objectId: entry.id, title: entry.title })),
+    ...avatars.slice(0, 3).map((entry) => ({ objectType: "avatar_profile" as const, objectId: entry.id, title: entry.title })),
+    ...exports.slice(0, 3).map((entry) => ({ objectType: "export_package" as const, objectId: entry.id, title: entry.title }))
+  ];
+
+  const resolvedPreviews = await Promise.all(
+    previewObjects.map(async (entry) => ({
+      ...entry,
+      resolved: await resolveObjectPolicy(context, entry.objectType, entry.objectId)
+    }))
+  );
+
+  return (
+    <PageShell currentPath="/policies" title="Policies" subtitle="Unify governance rules across passports, visas, agent packs, avatars, and exports with one object-level policy layer">
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Create or Update Policy" description="Direct policies override defaults and inherited rules for one governed object.">
+          <PolicyForm />
+        </SectionCard>
+
+        <SectionCard title="Direct Policy Registry" description="These are the explicit policy records stored in the local system.">
+          <div className="space-y-4">
+            {policies.map((policy) => (
+              <article key={policy.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap gap-2">
+                    <StatusBadge>{policy.objectType}</StatusBadge>
+                    {policy.privacyFloorOverride ? <StatusBadge>{policy.privacyFloorOverride}</StatusBadge> : null}
+                  </div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{policy.id}</p>
+                </div>
+                <p className="mt-3 font-medium">{policy.objectId}</p>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">secret {String(policy.allowSecretLinks)}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">machine {String(policy.allowMachineAccess)}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">export {String(policy.allowExports)}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">bind {String(policy.allowAvatarBinding)}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">simulate {String(policy.allowAvatarSimulation)}</span>
+                </div>
+                {policy.notes ? <p className="mt-3 text-[var(--muted)]">{policy.notes}</p> : null}
+              </article>
+            ))}
+            {policies.length === 0 ? <p className="text-sm text-[var(--muted)]">No direct object policies exist yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard title="Resolved Policy Preview" description="A sample of governed objects after inheritance and direct overrides are applied.">
+        <div className="space-y-4">
+          {resolvedPreviews.map((entry) => (
+            <article key={`${entry.objectType}:${entry.objectId}`} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium">{entry.title}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
+                    {entry.objectType} · {entry.objectId}
+                  </p>
+                </div>
+                {entry.resolved.privacyFloor ? <StatusBadge>{entry.resolved.privacyFloor}</StatusBadge> : null}
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                <span className="rounded-full bg-black/5 px-3 py-1">secret {String(entry.resolved.allowSecretLinks)}</span>
+                <span className="rounded-full bg-black/5 px-3 py-1">machine {String(entry.resolved.allowMachineAccess)}</span>
+                <span className="rounded-full bg-black/5 px-3 py-1">export {String(entry.resolved.allowExports)}</span>
+                <span className="rounded-full bg-black/5 px-3 py-1">bind {String(entry.resolved.allowAvatarBinding)}</span>
+                <span className="rounded-full bg-black/5 px-3 py-1">simulate {String(entry.resolved.allowAvatarSimulation)}</span>
+              </div>
+              <p className="mt-3 text-[var(--muted)]">
+                Chain: {entry.resolved.chain.map((segment) => `${segment.objectType}:${segment.objectId}`).join(" -> ")}
+              </p>
+            </article>
+          ))}
+          {resolvedPreviews.length === 0 ? <p className="text-sm text-[var(--muted)]">No governed objects are available for preview yet.</p> : null}
+        </div>
+      </SectionCard>
+    </PageShell>
+  );
+}

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Bot, Database, Download, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, Waypoints, Workflow } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Bot, Database, Download, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, SlidersHorizontal, Waypoints, Workflow } from "lucide-react";
 import clsx from "clsx";
 
 const navigation = [
@@ -15,6 +15,7 @@ const navigation = [
   { href: "/visas", label: "Visas", icon: Key },
   { href: "/avatars", label: "Avatars", icon: Bot },
   { href: "/exports", label: "Exports", icon: Download },
+  { href: "/policies", label: "Policies", icon: SlidersHorizontal },
   { href: "/grants", label: "Grants", icon: Key },
   { href: "/compilation-runs", label: "Compilation Runs", icon: Workflow },
   { href: "/health", label: "Health Center", icon: HeartPulse },

--- a/apps/web/src/components/policy-form.tsx
+++ b/apps/web/src/components/policy-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function PolicyForm() {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        startTransition(async () => {
+          const response = await fetch("/api/policies", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({
+              objectType: formData.get("objectType"),
+              objectId: formData.get("objectId"),
+              privacyFloorOverride: formData.get("privacyFloorOverride") || undefined,
+              allowSecretLinks: formData.get("allowSecretLinks") === "on" ? true : undefined,
+              allowMachineAccess: formData.get("allowMachineAccess") === "on" ? true : undefined,
+              allowExports: formData.get("allowExports") === "on" ? true : undefined,
+              allowAvatarBinding: formData.get("allowAvatarBinding") === "on" ? true : undefined,
+              allowAvatarSimulation: formData.get("allowAvatarSimulation") === "on" ? true : undefined,
+              notes: formData.get("notes") || ""
+            })
+          });
+
+          const payload = await response.json();
+          setMessage(response.ok ? `Policy saved: ${payload.policyId}` : payload.error ?? "Policy save failed");
+          if (response.ok) {
+            router.refresh();
+          }
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2 text-sm">
+          <span>Object Type</span>
+          <select name="objectType" defaultValue="visa_bundle" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="passport_snapshot">passport_snapshot</option>
+            <option value="visa_bundle">visa_bundle</option>
+            <option value="agent_pack_snapshot">agent_pack_snapshot</option>
+            <option value="avatar_profile">avatar_profile</option>
+            <option value="export_package">export_package</option>
+          </select>
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Object ID</span>
+          <input name="objectId" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Privacy Floor Override</span>
+          <select name="privacyFloorOverride" defaultValue="" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="">No override</option>
+            <option value="L0_SELF">L0_SELF</option>
+            <option value="L1_LOCAL_AI">L1_LOCAL_AI</option>
+            <option value="L2_INVITED">L2_INVITED</option>
+            <option value="L3_PUBLIC">L3_PUBLIC</option>
+            <option value="L4_AGENT_ONLY">L4_AGENT_ONLY</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="grid gap-3 rounded-3xl border border-[var(--line)] bg-white/80 p-4 md:grid-cols-2">
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="allowSecretLinks" className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Allow secret links</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="allowMachineAccess" className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Allow machine access</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="allowExports" className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Allow exports</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="allowAvatarBinding" className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Allow avatar binding</span>
+        </label>
+        <label className="flex items-center gap-3 text-sm">
+          <input type="checkbox" name="allowAvatarSimulation" className="h-4 w-4 rounded border-[var(--line)]" />
+          <span>Allow avatar simulation</span>
+        </label>
+      </div>
+
+      <label className="space-y-2 text-sm">
+        <span>Notes</span>
+        <textarea name="notes" rows={3} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Saving..." : "Save Policy"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/server/db/init.ts
+++ b/apps/web/src/server/db/init.ts
@@ -273,6 +273,21 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       updated_at text not null
     );
 
+    create table if not exists object_policies (
+      id text primary key,
+      object_type text not null,
+      object_id text not null,
+      privacy_floor_override text,
+      allow_secret_links integer,
+      allow_machine_access integer,
+      allow_exports integer,
+      allow_avatar_binding integer,
+      allow_avatar_simulation integer,
+      notes text not null default '',
+      created_at text not null,
+      updated_at text not null
+    );
+
     create table if not exists research_sessions (
       id text primary key,
       question text not null,

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -251,6 +251,21 @@ export const exportPackages = sqliteTable("export_packages", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const objectPolicies = sqliteTable("object_policies", {
+  id: text("id").primaryKey(),
+  objectType: text("object_type").notNull(),
+  objectId: text("object_id").notNull(),
+  privacyFloorOverride: text("privacy_floor_override"),
+  allowSecretLinks: integer("allow_secret_links"),
+  allowMachineAccess: integer("allow_machine_access"),
+  allowExports: integer("allow_exports"),
+  allowAvatarBinding: integer("allow_avatar_binding"),
+  allowAvatarSimulation: integer("allow_avatar_simulation"),
+  notes: text("notes").notNull().default(""),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
 export const researchSessions = sqliteTable("research_sessions", {
   id: text("id").primaryKey(),
   question: text("question").notNull(),

--- a/apps/web/src/server/services/agent-packs.ts
+++ b/apps/web/src/server/services/agent-packs.ts
@@ -7,6 +7,7 @@ import { agentPackSnapshots, passportSnapshots, postcards, visaBundles, wikiNode
 
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray } from "./common";
+import { assertPolicyAllows } from "./policies";
 import { canIncludeInPassport } from "./privacy";
 
 type PackNode = {
@@ -171,6 +172,16 @@ function parsePackSnapshot(row: typeof agentPackSnapshots.$inferSelect): AgentPa
 }
 
 export async function createAgentPackSnapshot(context: AppContext, input: AgentPackCreateInput) {
+  let effectivePrivacyFloor = input.privacyFloor;
+  if (input.passportId) {
+    const sourcePolicy = await assertPolicyAllows(context, "passport_snapshot", input.passportId, "avatar_binding");
+    effectivePrivacyFloor = sourcePolicy.privacyFloor ?? input.privacyFloor;
+  }
+  if (input.visaId) {
+    const sourcePolicy = await assertPolicyAllows(context, "visa_bundle", input.visaId, "avatar_binding");
+    effectivePrivacyFloor = sourcePolicy.privacyFloor ?? input.privacyFloor;
+  }
+
   const resolved = await resolveSourceSelections(context, input);
   if (!resolved.includeNodeIds.length && !resolved.includePostcardIds.length) {
     throw new Error("Agent packs must include at least one node or postcard, or inherit them from a source passport/visa.");
@@ -198,7 +209,7 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
   }
 
   const nodes: PackNode[] = nodeRows
-    .filter((node) => canIncludeInPassport(node.privacyLevel as PrivacyLevel, input.privacyFloor))
+    .filter((node) => canIncludeInPassport(node.privacyLevel as PrivacyLevel, effectivePrivacyFloor))
     .map((node) => ({
       id: node.id,
       title: node.title,
@@ -208,7 +219,7 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
     }));
 
   const cards: PackPostcard[] = postcardRows
-    .filter((card) => canIncludeInPassport(card.privacyLevel as PrivacyLevel, input.privacyFloor))
+    .filter((card) => canIncludeInPassport(card.privacyLevel as PrivacyLevel, effectivePrivacyFloor))
     .map((card) => ({
       id: card.id,
       title: card.title,
@@ -234,7 +245,7 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
     title: input.title,
     sourcePassportId: resolved.sourcePassportId,
     sourceVisaId: resolved.sourceVisaId,
-    privacyFloor: input.privacyFloor,
+    privacyFloor: effectivePrivacyFloor,
     nodes,
     postcards: cards
   });
@@ -248,7 +259,7 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
     machineManifestJson: JSON.stringify(machineManifest),
     includeNodeIdsJson: JSON.stringify(nodes.map((node) => node.id)),
     includePostcardIdsJson: JSON.stringify(cards.map((card) => card.id)),
-    privacyFloor: input.privacyFloor,
+    privacyFloor: effectivePrivacyFloor,
     createdAt: nowIso()
   });
 

--- a/apps/web/src/server/services/avatars.ts
+++ b/apps/web/src/server/services/avatars.ts
@@ -24,6 +24,7 @@ import {
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray, parseJsonObject } from "./common";
 import { getAgentPackSnapshot } from "./agent-packs";
+import { assertPolicyAllows, resolveObjectPolicy } from "./policies";
 
 type AvatarProfileRow = typeof avatarProfiles.$inferSelect;
 type AvatarSimulationSessionRow = typeof avatarSimulationSessions.$inferSelect;
@@ -252,6 +253,7 @@ async function createSimulationSession(
 
 export async function createAvatarProfile(context: AppContext, input: AvatarProfileCreateInput) {
   await ensureAgentPackExists(context, input.activePackId);
+  await assertPolicyAllows(context, "agent_pack_snapshot", input.activePackId, "avatar_binding");
 
   const avatarId = createId("avatar");
   const timestamp = nowIso();
@@ -308,6 +310,7 @@ export async function updateAvatarProfile(context: AppContext, avatarId: string,
 
   if (input.activePackId) {
     await ensureAgentPackExists(context, input.activePackId);
+    await assertPolicyAllows(context, "agent_pack_snapshot", input.activePackId, "avatar_binding");
   }
 
   await context.db
@@ -378,6 +381,26 @@ export async function simulateAvatar(context: AppContext, avatarId: string, inpu
   const profile = await getAvatarProfile(context, avatarId);
   if (!profile) {
     throw new Error("Avatar profile not found.");
+  }
+
+  const profilePolicy = await resolveObjectPolicy(context, "avatar_profile", avatarId);
+  if (!profilePolicy.allowAvatarSimulation) {
+    const answerMd = "This avatar is not permitted to simulate replies under the current object policy.";
+    const sessionId = await createSimulationSession(context, {
+      avatarProfileId: profile.id,
+      question: input.question,
+      resultStatus: "refused",
+      answerMd,
+      citations: [],
+      reason: "policy_avatar_simulation_disabled"
+    });
+    return {
+      sessionId,
+      resultStatus: "refused" as const,
+      answerMd,
+      citations: [],
+      reason: "policy_avatar_simulation_disabled"
+    };
   }
 
   if (profile.status === "paused") {

--- a/apps/web/src/server/services/exports.ts
+++ b/apps/web/src/server/services/exports.ts
@@ -23,6 +23,7 @@ import { writeAuditLog } from "./audit";
 import { getAgentPackSnapshot } from "./agent-packs";
 import { createId, nowIso, parseJsonArray } from "./common";
 import { getAvatarProfile } from "./avatars";
+import { assertPolicyAllows } from "./policies";
 
 const FORMAT_VERSION = "agent-pack-export/v1";
 
@@ -181,6 +182,10 @@ function buildBundleReadme(input: {
 
 export async function createAgentPackExportPackage(context: AppContext, input: AgentPackExportCreateInput) {
   const resolved = await resolveExportData(context, input);
+  await assertPolicyAllows(context, "agent_pack_snapshot", resolved.pack.id, "exports");
+  if (resolved.avatar) {
+    await assertPolicyAllows(context, "avatar_profile", resolved.avatar.id, "exports");
+  }
   const exportId = createId("export");
   const fileName = `${slugify(resolved.pack.title)}-${exportId}.zip`;
   const filePath = path.join(context.paths.exportsDir, fileName);

--- a/apps/web/src/server/services/policies.ts
+++ b/apps/web/src/server/services/policies.ts
@@ -1,0 +1,288 @@
+import { eq } from "drizzle-orm";
+
+import type {
+  ObjectPolicyObjectType,
+  ObjectPolicyRecord,
+  ObjectPolicyUpsertInput,
+  PrivacyLevel,
+  ResolvedObjectPolicy
+} from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import {
+  agentPackSnapshots,
+  avatarProfiles,
+  exportPackages,
+  objectPolicies,
+  passportSnapshots,
+  visaBundles
+} from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso } from "./common";
+import { getPrivacyRank } from "./privacy";
+
+type PolicyRow = typeof objectPolicies.$inferSelect;
+
+const defaultAllowances = {
+  allowSecretLinks: true,
+  allowMachineAccess: true,
+  allowExports: true,
+  allowAvatarBinding: true,
+  allowAvatarSimulation: true
+};
+
+function toNullableBoolean(value: number | null | undefined) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return Boolean(value);
+}
+
+function toStoredBoolean(value: boolean | undefined) {
+  if (value === undefined) {
+    return null;
+  }
+  return value ? 1 : 0;
+}
+
+function parsePolicyRow(row: PolicyRow): ObjectPolicyRecord {
+  return {
+    id: row.id,
+    objectType: row.objectType as ObjectPolicyObjectType,
+    objectId: row.objectId,
+    privacyFloorOverride: (row.privacyFloorOverride as PrivacyLevel | null) ?? null,
+    allowSecretLinks: toNullableBoolean(row.allowSecretLinks),
+    allowMachineAccess: toNullableBoolean(row.allowMachineAccess),
+    allowExports: toNullableBoolean(row.allowExports),
+    allowAvatarBinding: toNullableBoolean(row.allowAvatarBinding),
+    allowAvatarSimulation: toNullableBoolean(row.allowAvatarSimulation),
+    notes: row.notes,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+async function getDirectPolicy(context: AppContext, objectType: ObjectPolicyObjectType, objectId: string) {
+  const row = await context.db.query.objectPolicies.findFirst({
+    where: (table, { and, eq }) => and(eq(table.objectType, objectType), eq(table.objectId, objectId))
+  });
+  return row ? parsePolicyRow(row) : null;
+}
+
+async function getParentObject(context: AppContext, objectType: ObjectPolicyObjectType, objectId: string) {
+  if (objectType === "passport_snapshot") {
+    return null;
+  }
+
+  if (objectType === "visa_bundle") {
+    const visa = await context.db.query.visaBundles.findFirst({
+      where: eq(visaBundles.id, objectId)
+    });
+    return visa?.passportId ? { objectType: "passport_snapshot" as const, objectId: visa.passportId } : null;
+  }
+
+  if (objectType === "agent_pack_snapshot") {
+    const pack = await context.db.query.agentPackSnapshots.findFirst({
+      where: eq(agentPackSnapshots.id, objectId)
+    });
+    if (!pack) {
+      return null;
+    }
+    if (pack.sourceVisaId) {
+      return { objectType: "visa_bundle" as const, objectId: pack.sourceVisaId };
+    }
+    if (pack.sourcePassportId) {
+      return { objectType: "passport_snapshot" as const, objectId: pack.sourcePassportId };
+    }
+    return null;
+  }
+
+  if (objectType === "avatar_profile") {
+    const avatar = await context.db.query.avatarProfiles.findFirst({
+      where: eq(avatarProfiles.id, objectId)
+    });
+    return avatar ? { objectType: "agent_pack_snapshot" as const, objectId: avatar.activePackId } : null;
+  }
+
+  if (objectType === "export_package") {
+    const exportPackage = await context.db.query.exportPackages.findFirst({
+      where: eq(exportPackages.id, objectId)
+    });
+    if (!exportPackage) {
+      return null;
+    }
+    if (exportPackage.objectType === "agent_pack_snapshot") {
+      return { objectType: "agent_pack_snapshot" as const, objectId: exportPackage.objectId };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+async function getNativePrivacyFloor(context: AppContext, objectType: ObjectPolicyObjectType, objectId: string): Promise<PrivacyLevel | null> {
+  if (objectType === "passport_snapshot") {
+    const row = await context.db.query.passportSnapshots.findFirst({
+      where: eq(passportSnapshots.id, objectId)
+    });
+    return (row?.privacyFloor as PrivacyLevel | undefined) ?? null;
+  }
+
+  if (objectType === "visa_bundle") {
+    const row = await context.db.query.visaBundles.findFirst({
+      where: eq(visaBundles.id, objectId)
+    });
+    return (row?.privacyFloor as PrivacyLevel | undefined) ?? null;
+  }
+
+  if (objectType === "agent_pack_snapshot") {
+    const row = await context.db.query.agentPackSnapshots.findFirst({
+      where: eq(agentPackSnapshots.id, objectId)
+    });
+    return (row?.privacyFloor as PrivacyLevel | undefined) ?? null;
+  }
+
+  if (objectType === "avatar_profile") {
+    const parent = await getParentObject(context, objectType, objectId);
+    if (!parent) {
+      return null;
+    }
+    return getNativePrivacyFloor(context, parent.objectType, parent.objectId);
+  }
+
+  if (objectType === "export_package") {
+    const parent = await getParentObject(context, objectType, objectId);
+    if (!parent) {
+      return null;
+    }
+    return getNativePrivacyFloor(context, parent.objectType, parent.objectId);
+  }
+
+  return null;
+}
+
+function pickEffectivePrivacyFloor(nativeFloor: PrivacyLevel | null, inheritedFloor: PrivacyLevel | null, overrideFloor: PrivacyLevel | null) {
+  if (!nativeFloor && !inheritedFloor && !overrideFloor) {
+    return null;
+  }
+
+  const candidates = [nativeFloor, inheritedFloor, overrideFloor].filter((value): value is PrivacyLevel => Boolean(value));
+  return candidates.sort((left, right) => getPrivacyRank(left) - getPrivacyRank(right))[0] ?? null;
+}
+
+export async function resolveObjectPolicy(
+  context: AppContext,
+  objectType: ObjectPolicyObjectType,
+  objectId: string
+): Promise<ResolvedObjectPolicy> {
+  const directPolicy = await getDirectPolicy(context, objectType, objectId);
+  const parent = await getParentObject(context, objectType, objectId);
+  const inherited = parent ? await resolveObjectPolicy(context, parent.objectType, parent.objectId) : null;
+  const nativePrivacyFloor = await getNativePrivacyFloor(context, objectType, objectId);
+
+  return {
+    objectType,
+    objectId,
+    privacyFloor: pickEffectivePrivacyFloor(
+      nativePrivacyFloor,
+      inherited?.privacyFloor ?? null,
+      directPolicy?.privacyFloorOverride ?? null
+    ),
+    allowSecretLinks: directPolicy?.allowSecretLinks ?? inherited?.allowSecretLinks ?? defaultAllowances.allowSecretLinks,
+    allowMachineAccess: directPolicy?.allowMachineAccess ?? inherited?.allowMachineAccess ?? defaultAllowances.allowMachineAccess,
+    allowExports: directPolicy?.allowExports ?? inherited?.allowExports ?? defaultAllowances.allowExports,
+    allowAvatarBinding: directPolicy?.allowAvatarBinding ?? inherited?.allowAvatarBinding ?? defaultAllowances.allowAvatarBinding,
+    allowAvatarSimulation: directPolicy?.allowAvatarSimulation ?? inherited?.allowAvatarSimulation ?? defaultAllowances.allowAvatarSimulation,
+    chain: [{ objectType, objectId }, ...(inherited?.chain ?? [])],
+    directPolicy
+  };
+}
+
+export async function upsertObjectPolicy(context: AppContext, input: ObjectPolicyUpsertInput) {
+  const existing = await context.db.query.objectPolicies.findFirst({
+    where: (table, { and, eq }) => and(eq(table.objectType, input.objectType), eq(table.objectId, input.objectId))
+  });
+
+  if (existing) {
+    await context.db
+      .update(objectPolicies)
+      .set({
+        privacyFloorOverride: input.privacyFloorOverride ?? null,
+        allowSecretLinks: toStoredBoolean(input.allowSecretLinks),
+        allowMachineAccess: toStoredBoolean(input.allowMachineAccess),
+        allowExports: toStoredBoolean(input.allowExports),
+        allowAvatarBinding: toStoredBoolean(input.allowAvatarBinding),
+        allowAvatarSimulation: toStoredBoolean(input.allowAvatarSimulation),
+        notes: input.notes,
+        updatedAt: nowIso()
+      })
+      .where(eq(objectPolicies.id, existing.id));
+
+    await writeAuditLog(context, {
+      actionType: "update_object_policy",
+      objectType: "object_policy",
+      objectId: existing.id,
+      result: "succeeded",
+      notes: `${input.objectType}:${input.objectId}`
+    });
+
+    return existing.id;
+  }
+
+  const policyId = createId("policy");
+  await context.db.insert(objectPolicies).values({
+    id: policyId,
+    objectType: input.objectType,
+    objectId: input.objectId,
+    privacyFloorOverride: input.privacyFloorOverride ?? null,
+    allowSecretLinks: toStoredBoolean(input.allowSecretLinks),
+    allowMachineAccess: toStoredBoolean(input.allowMachineAccess),
+    allowExports: toStoredBoolean(input.allowExports),
+    allowAvatarBinding: toStoredBoolean(input.allowAvatarBinding),
+    allowAvatarSimulation: toStoredBoolean(input.allowAvatarSimulation),
+    notes: input.notes,
+    createdAt: nowIso(),
+    updatedAt: nowIso()
+  });
+
+  await writeAuditLog(context, {
+    actionType: "create_object_policy",
+    objectType: "object_policy",
+    objectId: policyId,
+    result: "succeeded",
+    notes: `${input.objectType}:${input.objectId}`
+  });
+
+  return policyId;
+}
+
+export async function listObjectPolicies(context: AppContext, limit = 120) {
+  const rows = await context.db.query.objectPolicies.findMany({
+    limit
+  });
+
+  return rows.map(parsePolicyRow);
+}
+
+export async function assertPolicyAllows(
+  context: AppContext,
+  objectType: ObjectPolicyObjectType,
+  objectId: string,
+  capability: "secret_links" | "machine_access" | "exports" | "avatar_binding" | "avatar_simulation"
+) {
+  const resolved = await resolveObjectPolicy(context, objectType, objectId);
+
+  const allowed =
+    capability === "secret_links" ? resolved.allowSecretLinks
+      : capability === "machine_access" ? resolved.allowMachineAccess
+      : capability === "exports" ? resolved.allowExports
+      : capability === "avatar_binding" ? resolved.allowAvatarBinding
+      : resolved.allowAvatarSimulation;
+
+  if (!allowed) {
+    throw new Error(`Policy denied ${capability} for ${objectType}:${objectId}`);
+  }
+
+  return resolved;
+}

--- a/apps/web/src/server/services/visas.ts
+++ b/apps/web/src/server/services/visas.ts
@@ -34,6 +34,7 @@ import {
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray, parseJsonObject } from "./common";
 import { createGrant } from "./grants";
+import { assertPolicyAllows, resolveObjectPolicy } from "./policies";
 import { canIncludeInPassport } from "./privacy";
 
 type VisaNode = {
@@ -647,7 +648,19 @@ async function resolveVisaRowByToken(context: AppContext, token: string) {
 }
 
 export async function createVisaBundle(context: AppContext, input: VisaBundleCreateInput) {
-  const content = await loadVisaContent(context, input);
+  let effectivePrivacyFloor = input.privacyFloor;
+  if (input.passportId) {
+    const sourcePolicy = await assertPolicyAllows(context, "passport_snapshot", input.passportId, "secret_links");
+    effectivePrivacyFloor = sourcePolicy.privacyFloor ?? input.privacyFloor;
+    if (input.allowMachineDownload && !sourcePolicy.allowMachineAccess) {
+      throw new Error(`Policy denied machine_access for passport_snapshot:${input.passportId}`);
+    }
+  }
+
+  const content = await loadVisaContent(context, {
+    ...input,
+    privacyFloor: effectivePrivacyFloor
+  });
   const sourceMap = await loadVisaSourceMap(context, content);
 
   const visaId = createId("visa");
@@ -676,7 +689,7 @@ export async function createVisaBundle(context: AppContext, input: VisaBundleCre
     passportId: input.passportId ?? null,
     description: input.description,
     purpose: input.purpose,
-    privacyFloor: input.privacyFloor,
+    privacyFloor: effectivePrivacyFloor,
     expiresAt: input.expiresAt ?? null,
     allowMachineDownload: input.allowMachineDownload,
     status: initialStatus,
@@ -700,7 +713,7 @@ export async function createVisaBundle(context: AppContext, input: VisaBundleCre
     machineManifestJson: JSON.stringify(machineManifest),
     includeNodeIdsJson: JSON.stringify(content.nodes.map((node) => node.id)),
     includePostcardIdsJson: JSON.stringify(content.cards.map((card) => card.id)),
-    privacyFloor: input.privacyFloor,
+    privacyFloor: effectivePrivacyFloor,
     redactionJson: JSON.stringify(input.redaction),
     allowMachineDownload: input.allowMachineDownload ? 1 : 0,
     expiresAt: input.expiresAt ?? null,
@@ -892,6 +905,7 @@ export async function accessVisaBundleByToken(
   }
 
   const row = resolved.row;
+  const policy = await resolveObjectPolicy(context, "visa_bundle", row.id);
   const effectiveStatus = parseVisaStatus(row);
   if (effectiveStatus === "revoked") {
     await writeVisaAccessEvent(context, {
@@ -918,6 +932,17 @@ export async function accessVisaBundleByToken(
     return { status: "expired" };
   }
 
+  if (!policy.allowSecretLinks) {
+    await writeVisaAccessEvent(context, {
+      visaId: row.id,
+      accessType: mode === "human" ? "human_view" : "machine_download",
+      result: "denied",
+      denialReason: "policy_secret_links_disabled",
+      meta
+    });
+    return { status: "revoked" };
+  }
+
   if (mode === "human" && getHumanLimitExceeded(row)) {
     await writeVisaAccessEvent(context, {
       visaId: row.id,
@@ -929,12 +954,12 @@ export async function accessVisaBundleByToken(
     return { status: "human_limit_reached" };
   }
 
-  if (mode === "machine" && !row.allowMachineDownload) {
+  if (mode === "machine" && (!row.allowMachineDownload || !policy.allowMachineAccess)) {
     await writeVisaAccessEvent(context, {
       visaId: row.id,
       accessType: "machine_download",
       result: "denied",
-      denialReason: "machine_download_disabled",
+      denialReason: !row.allowMachineDownload ? "machine_download_disabled" : "policy_machine_access_disabled",
       meta
     });
     return { status: "machine_disabled" };

--- a/apps/web/src/server/tests/policies.test.ts
+++ b/apps/web/src/server/tests/policies.test.ts
@@ -1,0 +1,310 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import {
+  agentPackSnapshots,
+  avatarProfiles,
+  passportSnapshots,
+  postcards,
+  visaBundles,
+  wikiNodes
+} from "@/server/db/schema";
+import { createId } from "@/server/services/common";
+import { createAgentPackSnapshot } from "@/server/services/agent-packs";
+import { createAvatarProfile, simulateAvatar } from "@/server/services/avatars";
+import { createAgentPackExportPackage } from "@/server/services/exports";
+import { resolveObjectPolicy, upsertObjectPolicy } from "@/server/services/policies";
+import { createVisaBundle } from "@/server/services/visas";
+
+import { describe, expect, it } from "vitest";
+
+class StubProvider implements ModelProvider {
+  readonly isConfigured = true;
+  async extractStructured() { return { summary: "", keyClaims: [], concepts: [], themes: [], tags: [] }; }
+  async summarizeAndLink() { return { nodes: [], relationHints: [] }; }
+  async embedText() { return []; }
+  async transcribeAudio() { return ""; }
+  async generateAnswer() { return { answerMd: "", citations: [] }; }
+  async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
+  async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateAvatarReply() { return { answerMd: "avatar answer", citations: [] }; }
+}
+
+async function createTestContext(prefix: string) {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const dataDir = path.join(tempRoot, "data");
+  await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+  return createAppContext({
+    dataDir,
+    databasePath: path.join(dataDir, "test.sqlite"),
+    provider: new StubProvider()
+  });
+}
+
+async function seedGovernedObjects(context: ReturnType<typeof createAppContext>) {
+  const timestamp = new Date().toISOString();
+  const nodeId = createId("node");
+  const cardId = createId("card");
+  const passportId = createId("passport");
+
+  await context.db.insert(wikiNodes).values({
+    id: nodeId,
+    nodeType: "summary",
+    title: "Governed Node",
+    summary: "Node summary",
+    bodyMd: "Node body for governed policy tests",
+    status: "accepted",
+    sourceIdsJson: JSON.stringify([]),
+    tagsJson: JSON.stringify(["policy"]),
+    projectKey: "atlas",
+    privacyLevel: "L2_INVITED",
+    embeddingJson: null,
+    updatedAt: timestamp,
+    createdAt: timestamp
+  });
+
+  await context.db.insert(postcards).values({
+    id: cardId,
+    cardType: "knowledge",
+    title: "Governed Card",
+    claim: "Governed claim",
+    evidenceSummary: "Governed evidence",
+    userView: "Governed view",
+    relatedNodeIdsJson: JSON.stringify([nodeId]),
+    relatedSourceIdsJson: JSON.stringify([]),
+    privacyLevel: "L2_INVITED",
+    version: 1,
+    updatedAt: timestamp,
+    createdAt: timestamp
+  });
+
+  await context.db.insert(passportSnapshots).values({
+    id: passportId,
+    title: "Governed Passport",
+    humanMarkdown: "# Governed Passport",
+    machineManifestJson: JSON.stringify({ title: "Governed Passport" }),
+    includeNodeIdsJson: JSON.stringify([nodeId]),
+    includePostcardIdsJson: JSON.stringify([cardId]),
+    privacyFloor: "L2_INVITED",
+    createdAt: timestamp
+  });
+
+  const visa = await createVisaBundle(context, {
+    title: "Governed Visa",
+    passportId,
+    includeNodeIds: [],
+    includePostcardIds: [],
+    privacyFloor: "L3_PUBLIC",
+    audienceLabel: "Reviewers",
+    description: "",
+    purpose: "",
+    allowMachineDownload: true,
+    redaction: {
+      hideOriginUrls: false,
+      hideSourcePaths: false,
+      hideRawSourceIds: false
+    }
+  });
+
+  const pack = await createAgentPackSnapshot(context, {
+    title: "Governed Pack",
+    visaId: visa.visaId,
+    passportId: undefined,
+    includeNodeIds: [],
+    includePostcardIds: [],
+    privacyFloor: "L3_PUBLIC"
+  });
+
+  const avatar = await createAvatarProfile(context, {
+    title: "Governed Avatar",
+    activePackId: pack.packId,
+    intro: "Governed intro",
+    toneRules: ["calm"],
+    forbiddenTopics: [],
+    escalationRules: {
+      escalateOnForbiddenTopic: true,
+      escalateOnInsufficientEvidence: true,
+      escalateOnOutOfScope: true
+    },
+    status: "active"
+  });
+
+  return {
+    nodeId,
+    cardId,
+    passportId,
+    visaId: visa.visaId,
+    packId: pack.packId,
+    avatarId: avatar.avatarId
+  };
+}
+
+describe("object policies", () => {
+  it("resolves inherited policies across passport -> visa -> pack -> avatar", async () => {
+    const context = await createTestContext("akp-policy-chain-");
+    const fixture = await seedGovernedObjects(context);
+
+    await upsertObjectPolicy(context, {
+      objectType: "passport_snapshot",
+      objectId: fixture.passportId,
+      privacyFloorOverride: "L1_LOCAL_AI",
+      allowSecretLinks: false,
+      allowMachineAccess: false,
+      allowExports: false,
+      notes: "base passport rule"
+    });
+
+    const avatarPolicy = await resolveObjectPolicy(context, "avatar_profile", fixture.avatarId);
+    expect(avatarPolicy.privacyFloor).toBe("L1_LOCAL_AI");
+    expect(avatarPolicy.allowSecretLinks).toBe(false);
+    expect(avatarPolicy.allowMachineAccess).toBe(false);
+    expect(avatarPolicy.allowExports).toBe(false);
+    expect(avatarPolicy.allowAvatarBinding).toBe(true);
+    expect(avatarPolicy.chain.map((entry) => entry.objectType)).toEqual([
+      "avatar_profile",
+      "agent_pack_snapshot",
+      "visa_bundle",
+      "passport_snapshot"
+    ]);
+  });
+
+  it("blocks visa creation when the source passport policy denies secret links", async () => {
+    const context = await createTestContext("akp-policy-visa-");
+    const timestamp = new Date().toISOString();
+    const nodeId = createId("node");
+    const cardId = createId("card");
+    const passportId = createId("passport");
+
+    await context.db.insert(wikiNodes).values({
+      id: nodeId,
+      nodeType: "summary",
+      title: "Visa Policy Node",
+      summary: "Node summary",
+      bodyMd: "Node body",
+      status: "accepted",
+      sourceIdsJson: JSON.stringify([]),
+      tagsJson: JSON.stringify(["policy"]),
+      projectKey: "atlas",
+      privacyLevel: "L2_INVITED",
+      embeddingJson: null,
+      updatedAt: timestamp,
+      createdAt: timestamp
+    });
+    await context.db.insert(postcards).values({
+      id: cardId,
+      cardType: "knowledge",
+      title: "Visa Policy Card",
+      claim: "Claim",
+      evidenceSummary: "Evidence",
+      userView: "View",
+      relatedNodeIdsJson: JSON.stringify([nodeId]),
+      relatedSourceIdsJson: JSON.stringify([]),
+      privacyLevel: "L2_INVITED",
+      version: 1,
+      updatedAt: timestamp,
+      createdAt: timestamp
+    });
+    await context.db.insert(passportSnapshots).values({
+      id: passportId,
+      title: "Passport",
+      humanMarkdown: "# Passport",
+      machineManifestJson: JSON.stringify({ title: "Passport" }),
+      includeNodeIdsJson: JSON.stringify([nodeId]),
+      includePostcardIdsJson: JSON.stringify([cardId]),
+      privacyFloor: "L2_INVITED",
+      createdAt: timestamp
+    });
+
+    await upsertObjectPolicy(context, {
+      objectType: "passport_snapshot",
+      objectId: passportId,
+      allowSecretLinks: false,
+      notes: "no secret links"
+    });
+
+    await expect(
+      createVisaBundle(context, {
+        title: "Blocked Visa",
+        passportId,
+        includeNodeIds: [],
+        includePostcardIds: [],
+        privacyFloor: "L3_PUBLIC",
+        audienceLabel: "Reviewers",
+        description: "",
+        purpose: "",
+        allowMachineDownload: true,
+        redaction: {
+          hideOriginUrls: false,
+          hideSourcePaths: false,
+          hideRawSourceIds: false
+        }
+      })
+    ).rejects.toThrow("Policy denied secret_links");
+  });
+
+  it("blocks avatar binding and simulation when policies disable them", async () => {
+    const context = await createTestContext("akp-policy-avatar-");
+    const fixture = await seedGovernedObjects(context);
+
+    await upsertObjectPolicy(context, {
+      objectType: "agent_pack_snapshot",
+      objectId: fixture.packId,
+      allowAvatarBinding: false,
+      notes: "no new avatars"
+    });
+
+    await expect(
+      createAvatarProfile(context, {
+        title: "Blocked Avatar",
+        activePackId: fixture.packId,
+        intro: "",
+        toneRules: [],
+        forbiddenTopics: [],
+        escalationRules: {
+          escalateOnForbiddenTopic: true,
+          escalateOnInsufficientEvidence: true,
+          escalateOnOutOfScope: true
+        },
+        status: "active"
+      })
+    ).rejects.toThrow("Policy denied avatar_binding");
+
+    await upsertObjectPolicy(context, {
+      objectType: "avatar_profile",
+      objectId: fixture.avatarId,
+      allowAvatarSimulation: false,
+      notes: "simulation off"
+    });
+
+    const result = await simulateAvatar(context, fixture.avatarId, {
+      question: "What is this pack for?"
+    });
+    expect(result.resultStatus).toBe("refused");
+    expect(result.reason).toBe("policy_avatar_simulation_disabled");
+  });
+
+  it("blocks export creation when the agent pack policy denies exports", async () => {
+    const context = await createTestContext("akp-policy-export-");
+    const fixture = await seedGovernedObjects(context);
+
+    await upsertObjectPolicy(context, {
+      objectType: "agent_pack_snapshot",
+      objectId: fixture.packId,
+      allowExports: false,
+      notes: "no exports"
+    });
+
+    await expect(
+      createAgentPackExportPackage(context, {
+        agentPackId: fixture.packId,
+        includeAvatarProfile: false
+      })
+    ).rejects.toThrow("Policy denied exports");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -128,6 +128,14 @@ export const exportPackageStatuses = [
   "failed"
 ] as const;
 
+export const objectPolicyObjectTypes = [
+  "passport_snapshot",
+  "visa_bundle",
+  "agent_pack_snapshot",
+  "avatar_profile",
+  "export_package"
+] as const;
+
 export const sourceTypeSchema = z.enum(sourceTypes);
 export const privacyLevelSchema = z.enum(privacyLevels);
 export const sourceStatusSchema = z.enum(sourceStatuses);
@@ -147,6 +155,7 @@ export const visaFeedbackStatusSchema = z.enum(visaFeedbackStatuses);
 export const avatarStatusSchema = z.enum(avatarStatuses);
 export const avatarSimulationStatusSchema = z.enum(avatarSimulationStatuses);
 export const exportPackageStatusSchema = z.enum(exportPackageStatuses);
+export const objectPolicyObjectTypeSchema = z.enum(objectPolicyObjectTypes);
 
 export const importPayloadSchema = z.object({
   type: sourceTypeSchema,
@@ -287,6 +296,18 @@ export const agentPackExportCreateSchema = z.object({
   includeAvatarProfile: z.boolean().default(false)
 });
 
+export const objectPolicyUpsertSchema = z.object({
+  objectType: objectPolicyObjectTypeSchema,
+  objectId: z.string().min(1),
+  privacyFloorOverride: privacyLevelSchema.optional(),
+  allowSecretLinks: z.boolean().optional(),
+  allowMachineAccess: z.boolean().optional(),
+  allowExports: z.boolean().optional(),
+  allowAvatarBinding: z.boolean().optional(),
+  allowAvatarSimulation: z.boolean().optional(),
+  notes: z.string().default("")
+});
+
 export const backupCreateSchema = z.object({
   note: z.string().default("manual_backup")
 });
@@ -315,6 +336,7 @@ export type VisaFeedbackStatus = z.infer<typeof visaFeedbackStatusSchema>;
 export type AvatarStatus = z.infer<typeof avatarStatusSchema>;
 export type AvatarSimulationStatus = z.infer<typeof avatarSimulationStatusSchema>;
 export type ExportPackageStatus = z.infer<typeof exportPackageStatusSchema>;
+export type ObjectPolicyObjectType = z.infer<typeof objectPolicyObjectTypeSchema>;
 export type ImportPayload = z.infer<typeof importPayloadSchema>;
 export type ResearchQuery = z.infer<typeof researchQuerySchema>;
 export type OutputCreateInput = z.infer<typeof outputCreateSchema>;
@@ -330,6 +352,7 @@ export type AvatarProfileCreateInput = z.infer<typeof avatarProfileCreateSchema>
 export type AvatarProfileUpdateInput = z.infer<typeof avatarProfileUpdateSchema>;
 export type AvatarSimulationInput = z.infer<typeof avatarSimulationInputSchema>;
 export type AgentPackExportCreateInput = z.infer<typeof agentPackExportCreateSchema>;
+export type ObjectPolicyUpsertInput = z.infer<typeof objectPolicyUpsertSchema>;
 export type BackupCreateInput = z.infer<typeof backupCreateSchema>;
 export type BackupRestoreInput = z.infer<typeof backupRestoreSchema>;
 
@@ -455,4 +478,32 @@ export type ExportPackageSummary = {
 
 export type ExportPackageSnapshot = ExportPackageSummary & {
   manifest: Record<string, unknown>;
+};
+
+export type ObjectPolicyRecord = {
+  id: string;
+  objectType: ObjectPolicyObjectType;
+  objectId: string;
+  privacyFloorOverride: PrivacyLevel | null;
+  allowSecretLinks: boolean | null;
+  allowMachineAccess: boolean | null;
+  allowExports: boolean | null;
+  allowAvatarBinding: boolean | null;
+  allowAvatarSimulation: boolean | null;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ResolvedObjectPolicy = {
+  objectType: ObjectPolicyObjectType;
+  objectId: string;
+  privacyFloor: PrivacyLevel | null;
+  allowSecretLinks: boolean;
+  allowMachineAccess: boolean;
+  allowExports: boolean;
+  allowAvatarBinding: boolean;
+  allowAvatarSimulation: boolean;
+  chain: Array<{ objectType: ObjectPolicyObjectType; objectId: string }>;
+  directPolicy: ObjectPolicyRecord | null;
 };


### PR DESCRIPTION
## Summary
- add first-class object policy records and a resolved policy engine
- add internal policy APIs and a /policies workshop page
- enforce policy checks across visas, agent packs, avatars, and exports

## Validation
- npm run verify
