### PR TITLE
Refocus product around AI-mountable knowledge context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # AI Personal Knowledge Passport System
 
-This project is a local-first personal knowledge compiler. It continuously compiles raw materials into a traceable personal wiki, then organizes selected and authorized parts into knowledge postcards, knowledge passports, and future scenario-specific visa bundles.
+This project is an AI-mountable personal knowledge base. It compiles raw materials into a traceable local knowledge system, then packages the right subset into postcards, passports, visas, and governed agent layers so any AI can understand the user quickly under authorization.
 
-The public repository currently implements a single-user Web system with this end-to-end loop:
+The canonical product flow is:
 
-`import -> incremental compile -> local Q&A -> formal output -> flowback -> postcards -> lightweight passport -> local backup`
+`import -> compile -> signals -> postcards -> passport -> mount`
+
+Writeback still remains candidate-only and user-reviewed.
 
 ## Project Status
 
 - Stage: public MVP / early open-source phase
-- Product direction: local-first, traceable sources, AI-maintained, user-governed
+- Product direction: local-first, traceable sources, AI-readable context, user-governed
 - Current scope: single user, local runtime, OpenAI-first provider, SQLite persistence
 
 ## What Exists Today
@@ -18,6 +20,7 @@ The public repository currently implements a single-user Web system with this en
 - Local object storage and SQLite data model
 - Hybrid retrieval with FTS5 + embeddings
 - Knowledge compilation, review queue, research Q&A, and output flowback
+- Workspace-scoped context with `Focus Cards`, `Capability Signals`, and `Mistake Patterns`
 - Postcard generation, passport snapshot generation, and backup zip exports
 - Visa bundle generation, managed secret-link sharing, machine-manifest downloads, and lightweight external flowback
 - Agent pack snapshots, avatar profiles, and governed internal-only simulation sessions
@@ -29,25 +32,37 @@ The public repository currently implements a single-user Web system with this en
 
 ## Current App Surfaces
 
-The current app shell includes:
+The current app shell is grouped into:
+
+Core:
 
 - `Dashboard`
 - `Inbox`
 - `Knowledge`
+- `Signals`
+- `Postcards`
+- `Passport`
 - `Review Queue`
 - `Research`
-- `Outputs`
-- `Postcards`
-- `Health Center`
-- `Visuals`
-- `Audit Log`
-- `Passport & Backup`
-- `Visas`
+
+Advanced:
+
+- `Mount Center`
 - `Avatars`
-- `Avatar Sessions`
 - `Exports`
 - `Policies`
+- `Grants`
+- `Audit Log`
+- `Health Center`
+- `Visuals`
 - `Fragments`
+- `Compilation Runs`
+
+Compatibility surfaces still present in the app:
+
+- `Review Queue`
+- `Outputs`
+- `Avatar Sessions`
 
 ## Architecture
 
@@ -62,6 +77,29 @@ Core stack:
 - SQLite + Drizzle ORM + FTS5
 - OpenAI provider abstraction
 - Local worker queue
+
+## Product Promise
+
+The product is no longer framed as a general future-total knowledge OS.
+
+The primary promise is:
+
+**help any AI understand the user’s foundation, current goal, and common blind spots quickly under authorization**
+
+The new first-layer objects are:
+
+- `Workspace`
+- `Capability Signal`
+- `Mistake Pattern`
+- `Focus Card`
+
+The advanced layers remain:
+
+- `Passport`
+- `Visa`
+- `Agent Pack`
+- `Avatar`
+- `Export Package`
 
 ## Quick Start
 
@@ -174,30 +212,34 @@ npm run build
 - editor defaults are defined in `.editorconfig`
 - Node version hint lives in `.nvmrc`
 
-## Roadmap
+## Current Product Shape
 
-The GitHub repository now contains:
+Core context:
 
-- a closed `MVP` milestone that tracks the first shipped product baseline
-- an open `V1` milestone for the next structural system layers
+- raw sources
+- accepted knowledge nodes
+- capability signals
+- mistake patterns
+- active focus cards
+- postcards
+- passport manifests
 
-The current V1 tracking issues focus on:
+Governed downstream layers:
 
-- fragment-first evidence modeling
-- explicit claim modeling
-- grant-based authorization records
-- compilation run history and diffs
+- visas for mount-time narrowing
+- agent packs for bounded AI behavior
+- avatars for governed replies and live internal sessions
+- export packages for cross-AI portability
 
-There is also an explicit maintenance issue for the remaining red dependency upgrades.
+## Near-Term Direction
 
-Next major directions include:
+The current priority is not adding more abstract layers. It is tightening the product around the AI-readable entry surface:
 
-- first-class fragment visibility and traceability
-- first-class claim objects
-- explicit authorization grants and policy records
-- durable compilation-run history
-- managed sharing analytics and feedback review
-- future scenario bundles and agent governance
+- sharper passport generation
+- better learner-state synthesis
+- clearer workspace boundaries
+- stronger mount-time narrowing
+- stable downstream governed AI behavior
 
 For the full product-system framing, see [docs/project-blueprint.md](./docs/project-blueprint.md).
 

--- a/apps/web/src/app/api/focus-cards/[id]/activate/route.ts
+++ b/apps/web/src/app/api/focus-cards/[id]/activate/route.ts
@@ -1,0 +1,16 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { getAppContext } from "@/server/context";
+import { activateFocusCard } from "@/server/services/focus-cards";
+
+export async function POST(_: Request, props: { params: Promise<{ id: string }> }) {
+  try {
+    const params = await props.params;
+    const result = await activateFocusCard(getAppContext(), params.id);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Focus activation failed" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/api/focus-cards/route.ts
+++ b/apps/web/src/app/api/focus-cards/route.ts
@@ -1,0 +1,25 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { focusCardCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createFocusCard, listFocusCards } from "@/server/services/focus-cards";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const workspaceId = searchParams.get("workspaceId") || undefined;
+  const focusCards = await listFocusCards(getAppContext(), workspaceId);
+  return NextResponse.json({ focusCards });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = focusCardCreateSchema.parse(await request.json());
+    const result = await createFocusCard(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Focus card creation failed" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/api/imports/route.ts
+++ b/apps/web/src/app/api/imports/route.ts
@@ -14,6 +14,7 @@ export async function POST(request: Request) {
       type: formData.get("type"),
       title: formData.get("title"),
       originUrl: formData.get("originUrl") || undefined,
+      workspaceId: formData.get("workspaceId") || undefined,
       projectKey: formData.get("projectKey") || undefined,
       privacyLevel: formData.get("privacyLevel"),
       textContent: formData.get("textContent") || undefined,

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -14,7 +14,8 @@ export async function GET(request: Request) {
 
   const result = await searchKnowledge(getAppContext(), {
     q,
-    limit: Number(searchParams.get("limit") ?? "8")
+    limit: Number(searchParams.get("limit") ?? "8"),
+    workspaceId: searchParams.get("workspaceId") || undefined
   });
 
   return NextResponse.json(result);

--- a/apps/web/src/app/api/signals/capability/route.ts
+++ b/apps/web/src/app/api/signals/capability/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { capabilitySignalCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createCapabilitySignal, listCapabilitySignals } from "@/server/services/signals";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const workspaceId = searchParams.get("workspaceId") || undefined;
+  const status = searchParams.get("status") || undefined;
+  const signals = await listCapabilitySignals(getAppContext(), {
+    workspaceId,
+    status: status as ReturnType<typeof capabilitySignalCreateSchema.parse>["status"] | undefined
+  });
+  return NextResponse.json({ signals });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = capabilitySignalCreateSchema.parse(await request.json());
+    const result = await createCapabilitySignal(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Capability signal creation failed" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/api/signals/mistakes/route.ts
+++ b/apps/web/src/app/api/signals/mistakes/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { mistakePatternCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createMistakePattern, listMistakePatterns } from "@/server/services/signals";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const workspaceId = searchParams.get("workspaceId") || undefined;
+  const status = searchParams.get("status") || undefined;
+  const mistakes = await listMistakePatterns(getAppContext(), {
+    workspaceId,
+    status: status as ReturnType<typeof mistakePatternCreateSchema.parse>["status"] | undefined
+  });
+  return NextResponse.json({ mistakes });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = mistakePatternCreateSchema.parse(await request.json());
+    const result = await createMistakePattern(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Mistake pattern creation failed" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/api/workspaces/route.ts
+++ b/apps/web/src/app/api/workspaces/route.ts
@@ -1,0 +1,23 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { workspaceCreateSchema } from "@ai-knowledge-passport/shared";
+
+import { getAppContext } from "@/server/context";
+import { createWorkspace, listWorkspaces } from "@/server/services/workspaces";
+
+export async function GET() {
+  const workspaces = await listWorkspaces(getAppContext());
+  return NextResponse.json({ workspaces });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = workspaceCreateSchema.parse(await request.json());
+    const result = await createWorkspace(getAppContext(), payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Workspace creation failed" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/avatars/page.tsx
+++ b/apps/web/src/app/avatars/page.tsx
@@ -31,7 +31,7 @@ export default async function AvatarsPage() {
   const activeLiveSessions = liveSessions.filter((session) => session.status === "active").length;
 
   return (
-    <PageShell currentPath="/avatars" title="Avatars" subtitle="Configure governed agent packs, bind them to avatar profiles, and simulate refusal and escalation behavior safely">
+    <PageShell currentPath="/avatars" title="Avatars" subtitle="Bind governed agent packs to avatars so an AI can speak from passport-derived context inside explicit boundaries">
       <section className="grid gap-4 md:grid-cols-6">
         <StatTile label="Agent Packs" value={packs.length} />
         <StatTile label="Avatar Profiles" value={avatars.length} />
@@ -42,7 +42,7 @@ export default async function AvatarsPage() {
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-        <SectionCard title="Create Agent Pack" description="Snapshot a governed subset of passports, visas, nodes, and postcards as the knowledge boundary for a future avatar.">
+        <SectionCard title="Create Agent Pack" description="Snapshot a governed subset of passports, visas, nodes, and postcards as the knowledge boundary for a future avatar. Start from a passport or visa when possible.">
           <AgentPackForm
             passports={passports.map((passport) => ({ id: passport.id, title: passport.title }))}
             visas={visas.map((visa) => ({ id: visa.id, title: visa.title }))}
@@ -77,7 +77,7 @@ export default async function AvatarsPage() {
                 </div>
                 <div className="mt-4">
                   <Link href={`/exports?agentPackId=${pack.id}`} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
-                    Export Pack
+                    Export Agent Pack
                   </Link>
                 </div>
               </article>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -11,14 +11,57 @@ export default async function DashboardPage() {
   const stats = await getDashboardStats(getAppContext());
 
   return (
-    <PageShell currentPath="/dashboard" title="Dashboard" subtitle="Today’s knowledge growth and outward-facing projection overview">
-      <section className="grid gap-4 md:grid-cols-3">
+    <PageShell currentPath="/dashboard" title="Dashboard" subtitle="Track the core AI-readable context: imports, accepted knowledge, active focus, and what should be mounted next">
+      <section className="grid gap-4 md:grid-cols-4">
         <StatTile label="Imports Today" value={stats.importsToday} hint="Number of sources added today" />
         <StatTile label="Pending Compile" value={stats.pendingCompile} hint="Archived sources waiting for compilation" />
         <StatTile label="Pending Review" value={stats.pendingReview} hint="Compiled nodes waiting for user review" />
+        <StatTile label="Active Focus" value={stats.activeFocusCard?.title ?? "none"} hint={stats.activeFocusCard?.priority ?? "No active focus card"} />
       </section>
 
       <div className="grid gap-6 lg:grid-cols-2">
+        <SectionCard title="Current User Context" description="This is the high-level layer an AI should understand before it reads deeper knowledge.">
+          <div className="space-y-4">
+            <div className="rounded-3xl border border-[var(--line)] bg-white/70 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Active Focus</p>
+              {stats.activeFocusCard ? (
+                <>
+                  <p className="mt-3 text-lg font-semibold">{stats.activeFocusCard.title}</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{stats.activeFocusCard.goal}</p>
+                </>
+              ) : (
+                <p className="mt-3 text-sm text-[var(--muted)]">No active focus card yet. Use Signals to set what matters now.</p>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-[var(--line)] bg-white/70 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Top Capability Signals</p>
+              <div className="mt-3 space-y-3">
+                {stats.topSignals.map((signal) => (
+                  <article key={signal.id}>
+                    <p className="text-sm font-medium">{signal.topic}</p>
+                    <p className="mt-1 text-sm text-[var(--muted)]">{signal.observedPractice}</p>
+                  </article>
+                ))}
+                {stats.topSignals.length === 0 ? <p className="text-sm text-[var(--muted)]">No accepted capability signals yet.</p> : null}
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-[var(--line)] bg-white/70 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Mistake Patterns Pending Review</p>
+              <div className="mt-3 space-y-3">
+                {stats.pendingMistakes.map((mistake) => (
+                  <article key={mistake.id}>
+                    <p className="text-sm font-medium">{mistake.topic}</p>
+                    <p className="mt-1 text-sm text-[var(--muted)]">{mistake.description}</p>
+                  </article>
+                ))}
+                {stats.pendingMistakes.length === 0 ? <p className="text-sm text-[var(--muted)]">No mistake patterns are waiting for review.</p> : null}
+              </div>
+            </div>
+          </div>
+        </SectionCard>
+
         <SectionCard title="Recent Research Output" description="Review recent research sessions and formal outputs here.">
           <div className="space-y-4">
             {stats.recentResearch.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no research sessions yet.</p> : null}

--- a/apps/web/src/app/exports/page.tsx
+++ b/apps/web/src/app/exports/page.tsx
@@ -26,7 +26,7 @@ export default async function ExportsPage(props: {
   const latest = exports[0];
 
   return (
-    <PageShell currentPath="/exports" title="Exports" subtitle="Package governed agent packs into portable cross-AI zip bundles with stable manifests and checksums">
+    <PageShell currentPath="/exports" title="Exports" subtitle="Export governed agent packs as portable cross-AI bundles after the passport and mount layers are already in place">
       <section className="grid gap-4 md:grid-cols-4">
         <StatTile label="Export Packages" value={exports.length} />
         <StatTile label="Latest Export" value={latest?.title ?? "none"} hint={latest?.createdAt ?? "No export packages yet"} />
@@ -35,7 +35,7 @@ export default async function ExportsPage(props: {
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-        <SectionCard title="Create Cross-AI Bundle" description="Export an agent pack as a versioned zip bundle with manifest, pack snapshot, evidence-level node/card data, and optional avatar profile context.">
+        <SectionCard title="Create Cross-AI Bundle" description="Export an agent pack as a versioned zip bundle with manifest, pack snapshot, node/card evidence, and optional avatar profile context.">
           <ExportPackageForm
             packs={packs.map((pack) => ({ id: pack.id, title: pack.title }))}
             avatars={avatars.map((avatar) => ({ id: avatar.id, title: avatar.title, activePackId: avatar.activePackId }))}

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -8,15 +8,20 @@ import { SectionCard, StatusBadge } from "@/components/ui";
 import { getAppContext } from "@/server/context";
 import { parseJsonObject } from "@/server/services/common";
 import { listSources } from "@/server/services/sources";
+import { listWorkspaces } from "@/server/services/workspaces";
 
 export default async function InboxPage() {
-  const sources = await listSources(getAppContext());
+  const context = getAppContext();
+  const [sources, workspaces] = await Promise.all([
+    listSources(context),
+    listWorkspaces(context)
+  ]);
 
   return (
     <PageShell currentPath="/inbox" title="Inbox" subtitle="Bring everything into one place and send it into the compile queue">
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
         <SectionCard title="Import Sources" description="Supports markdown, txt, pdf, url, image, chat transcript, and audio.">
-          <ImportForm />
+          <ImportForm workspaces={workspaces} />
         </SectionCard>
         <SectionCard title="Inbox Queue" description="Each source keeps its origin, privacy level, latest job state, and processing status.">
           <div className="space-y-4">
@@ -42,7 +47,7 @@ export default async function InboxPage() {
                         </StatusBadge>
                       </div>
                       <p className="mt-3 text-sm text-[var(--muted)]">
-                        Privacy: {source.privacyLevel}
+                        Workspace: {source.workspaceId} · Privacy: {source.privacyLevel}
                         {source.projectKey ? ` · Project: ${source.projectKey}` : ""}
                       </p>
                       {normalization ? (

--- a/apps/web/src/app/passport/page.tsx
+++ b/apps/web/src/app/passport/page.tsx
@@ -10,24 +10,28 @@ import { SectionCard, StatusBadge } from "@/components/ui";
 import { getAppContext } from "@/server/context";
 import { listBackups } from "@/server/services/backups";
 import { listPassports } from "@/server/services/passports";
+import { listWorkspaces } from "@/server/services/workspaces";
 
 export default async function PassportPage() {
   const context = getAppContext();
-  const passports = await listPassports(context);
-  const backups = await listBackups(context);
+  const [passports, backups, workspaces] = await Promise.all([
+    listPassports(context),
+    listBackups(context),
+    listWorkspaces(context)
+  ]);
 
   return (
-    <PageShell currentPath="/passport" title="Passport & Backup" subtitle="Generate a lightweight knowledge passport and archive the current state safely">
+    <PageShell currentPath="/passport" title="Passport" subtitle="Publish the canonical AI entry object: postcards, active focus, capability signals, and blind spots in one governed manifest">
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-        <SectionCard title="Passport and Backup Controls" description="Passport generation runs through the queue, and backups package the database, object files, and manifest.">
+        <SectionCard title="Passport and Backup Controls" description="Passport generation packages the context an AI should read first. Backup remains a secondary recovery layer.">
           <div className="space-y-6">
             <div className="flex flex-wrap items-center gap-3 rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
-              <span className="text-[var(--muted)]">When you are ready to package a scenario-specific bundle, move into the Visa workshop.</span>
+              <span className="text-[var(--muted)]">After a passport is generated, move into Mount Center to narrow it into a visa bundle for a specific AI or scenario.</span>
               <Link href="/visas" className="rounded-full border border-[var(--line)] px-4 py-2">
-                Open Visa Workshop
+                Create Visa
               </Link>
             </div>
-            <PassportControls />
+            <PassportControls workspaces={workspaces} />
             <div className="rounded-3xl border border-[var(--line)] bg-white/70 p-4">
               <p className="text-sm leading-6 text-[var(--muted)]">
                 Backup restore currently extracts a selected archive into a clean target directory instead of overwriting the live runtime.
@@ -39,7 +43,7 @@ export default async function PassportPage() {
           </div>
         </SectionCard>
         <div className="space-y-6">
-          <SectionCard title="Passport Snapshots" description="Human-readable Markdown and machine-readable manifests are stored together.">
+          <SectionCard title="Passport Snapshots" description="Each passport now captures what an AI should know about the user before it reads deeper knowledge.">
             <div className="space-y-4">
               {passports.map((passport) => (
                 <article key={passport.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
@@ -55,6 +59,12 @@ export default async function PassportPage() {
                     <span className="rounded-full bg-black/5 px-3 py-1">cards {passport.includePostcardIds.length}</span>
                     <span className="rounded-full bg-black/5 px-3 py-1">
                       themes {Array.isArray(passport.machineManifest.themeMap) ? passport.machineManifest.themeMap.length : 0}
+                    </span>
+                    <span className="rounded-full bg-black/5 px-3 py-1">
+                      signals {typeof passport.machineManifest === "object" && Array.isArray((passport.machineManifest as { capabilitySignals?: unknown[] }).capabilitySignals) ? ((passport.machineManifest as { capabilitySignals?: unknown[] }).capabilitySignals?.length ?? 0) : 0}
+                    </span>
+                    <span className="rounded-full bg-black/5 px-3 py-1">
+                      focus {((passport.machineManifest as { focusCard?: unknown }).focusCard ? "active" : "none")}
                     </span>
                   </div>
                   <div className="prose prose-sm mt-4 max-w-none">

--- a/apps/web/src/app/review/actions.ts
+++ b/apps/web/src/app/review/actions.ts
@@ -4,12 +4,42 @@ import { revalidatePath } from "next/cache";
 
 import { getAppContext } from "@/server/context";
 import { applyReviewAction } from "@/server/services/compiler";
+import { reviewCapabilitySignal, reviewMistakePattern } from "@/server/services/signals";
 
 export async function submitReviewAction(formData: FormData) {
+  const itemType = String(formData.get("itemType") ?? "node");
   const nodeId = String(formData.get("nodeId") ?? "");
+  const signalId = String(formData.get("signalId") ?? "");
+  const mistakeId = String(formData.get("mistakeId") ?? "");
   const action = String(formData.get("action") ?? "");
   const note = String(formData.get("note") ?? "");
   const mergedIntoNodeId = String(formData.get("mergedIntoNodeId") ?? "");
+
+  if (itemType === "signal") {
+    if (!signalId || !["accept", "reject"].includes(action)) {
+      return;
+    }
+
+    await reviewCapabilitySignal(getAppContext(), signalId, action === "accept" ? "accepted" : "rejected");
+    revalidatePath("/review");
+    revalidatePath("/signals");
+    revalidatePath("/dashboard");
+    revalidatePath("/passport");
+    return;
+  }
+
+  if (itemType === "mistake") {
+    if (!mistakeId || !["accept", "reject"].includes(action)) {
+      return;
+    }
+
+    await reviewMistakePattern(getAppContext(), mistakeId, action === "accept" ? "accepted" : "rejected");
+    revalidatePath("/review");
+    revalidatePath("/signals");
+    revalidatePath("/dashboard");
+    revalidatePath("/passport");
+    return;
+  }
 
   if (!nodeId || !["accept", "reject", "rewrite", "merge"].includes(action)) {
     return;
@@ -25,4 +55,6 @@ export async function submitReviewAction(formData: FormData) {
   revalidatePath("/review");
   revalidatePath("/knowledge");
   revalidatePath("/dashboard");
+  revalidatePath("/signals");
+  revalidatePath("/passport");
 }

--- a/apps/web/src/app/review/page.tsx
+++ b/apps/web/src/app/review/page.tsx
@@ -4,13 +4,18 @@ import { PageShell } from "@/components/page-shell";
 import { SectionCard, StatusBadge } from "@/components/ui";
 import { getAppContext } from "@/server/context";
 import { listKnowledgeNodes } from "@/server/services/compiler";
+import { listCapabilitySignals, listMistakePatterns } from "@/server/services/signals";
 
 import { submitReviewAction } from "./actions";
 
 export default async function ReviewPage() {
   const context = getAppContext();
-  const nodes = await listKnowledgeNodes(context, "pending_review");
-  const acceptedNodes = await listKnowledgeNodes(context, "accepted");
+  const [nodes, acceptedNodes, pendingSignals, pendingMistakes] = await Promise.all([
+    listKnowledgeNodes(context, "pending_review"),
+    listKnowledgeNodes(context, "accepted"),
+    listCapabilitySignals(context, { status: "pending_review", limit: 40 }),
+    listMistakePatterns(context, { status: "pending_review", limit: 40 })
+  ]);
 
   return (
     <PageShell currentPath="/review" title="Review Queue" subtitle="Review compiled results before they enter the formal knowledge layer">
@@ -52,6 +57,74 @@ export default async function ReviewPage() {
           {nodes.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no pending review nodes right now.</p> : null}
         </div>
       </SectionCard>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Pending Capability Signals" description="These are evidence-backed signals that describe likely strengths and current gaps.">
+          <div className="space-y-4">
+            {pendingSignals.map((signal) => (
+              <article key={signal.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-5">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-lg font-semibold">{signal.topic}</p>
+                    <p className="mt-1 text-sm text-[var(--muted)]">{signal.observedPractice}</p>
+                  </div>
+                  <StatusBadge tone="warn">signal</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">Current gaps: {signal.currentGaps}</p>
+                <p className="mt-2 text-xs text-[var(--muted)]">
+                  Confidence {signal.confidence.toFixed(2)} · Nodes {signal.evidenceNodeIds.length} · Fragments {signal.evidenceFragmentIds.length}
+                </p>
+                <form action={submitReviewAction} className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_160px]">
+                  <input type="hidden" name="itemType" value="signal" />
+                  <input type="hidden" name="signalId" value={signal.id} />
+                  <textarea name="note" rows={3} className="rounded-2xl border border-[var(--line)] bg-white px-4 py-3 text-sm" placeholder="Optional note" />
+                  <div className="space-y-2">
+                    <select name="action" defaultValue="accept" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3 text-sm">
+                      <option value="accept">accept</option>
+                      <option value="reject">reject</option>
+                    </select>
+                    <button className="w-full rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white">Submit Review</button>
+                  </div>
+                </form>
+              </article>
+            ))}
+            {pendingSignals.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no pending capability signals right now.</p> : null}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Pending Mistake Patterns" description="Recurring misconceptions and blind spots should be reviewed before they shape passport context.">
+          <div className="space-y-4">
+            {pendingMistakes.map((mistake) => (
+              <article key={mistake.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-5">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-lg font-semibold">{mistake.topic}</p>
+                    <p className="mt-1 text-sm text-[var(--muted)]">{mistake.description}</p>
+                  </div>
+                  <StatusBadge tone="warn">mistake</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">Fix suggestions: {mistake.fixSuggestions}</p>
+                <p className="mt-2 text-xs text-[var(--muted)]">
+                  Recurrence {mistake.recurrenceCount} · Nodes {mistake.exampleNodeIds.length} · Fragments {mistake.exampleFragmentIds.length}
+                </p>
+                <form action={submitReviewAction} className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_160px]">
+                  <input type="hidden" name="itemType" value="mistake" />
+                  <input type="hidden" name="mistakeId" value={mistake.id} />
+                  <textarea name="note" rows={3} className="rounded-2xl border border-[var(--line)] bg-white px-4 py-3 text-sm" placeholder="Optional note" />
+                  <div className="space-y-2">
+                    <select name="action" defaultValue="accept" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3 text-sm">
+                      <option value="accept">accept</option>
+                      <option value="reject">reject</option>
+                    </select>
+                    <button className="w-full rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white">Submit Review</button>
+                  </div>
+                </form>
+              </article>
+            ))}
+            {pendingMistakes.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no pending mistake patterns right now.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
     </PageShell>
   );
 }

--- a/apps/web/src/app/signals/page.tsx
+++ b/apps/web/src/app/signals/page.tsx
@@ -1,0 +1,120 @@
+export const dynamic = "force-dynamic";
+
+import { FocusCardActivateButton } from "@/components/focus-card-activate-button";
+import { FocusCardForm } from "@/components/focus-card-form";
+import { PageShell } from "@/components/page-shell";
+import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
+import { getAppContext } from "@/server/context";
+import { listFocusCards } from "@/server/services/focus-cards";
+import { listCapabilitySignals, listMistakePatterns } from "@/server/services/signals";
+import { listWorkspaces } from "@/server/services/workspaces";
+
+export default async function SignalsPage() {
+  const context = getAppContext();
+  const [workspaces, focusCards, acceptedSignals, pendingSignals, acceptedMistakes, pendingMistakes] = await Promise.all([
+    listWorkspaces(context),
+    listFocusCards(context),
+    listCapabilitySignals(context, { status: "accepted", limit: 20 }),
+    listCapabilitySignals(context, { status: "pending_review", limit: 20 }),
+    listMistakePatterns(context, { status: "accepted", limit: 20 }),
+    listMistakePatterns(context, { status: "pending_review", limit: 20 })
+  ]);
+
+  const activeFocus = focusCards.find((card) => card.status === "active") ?? null;
+
+  return (
+    <PageShell currentPath="/signals" title="Signals" subtitle="Surface the context an AI should read first: your current goal, capability signals, and recurring blind spots">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatTile label="Accepted Signals" value={acceptedSignals.length} />
+        <StatTile label="Pending Signals" value={pendingSignals.length} />
+        <StatTile label="Tracked Mistakes" value={acceptedMistakes.length} />
+        <StatTile label="Active Focus" value={activeFocus?.title ?? "none"} hint={activeFocus?.priority ?? "Create one focus card"} />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <SectionCard title="Create Focus Card" description="Capture what matters now so mounted AI sessions read your current objective before your full history.">
+          <FocusCardForm workspaces={workspaces} defaultWorkspaceId={workspaces[0]?.id} />
+        </SectionCard>
+
+        <SectionCard title="Focus Cards" description="Only one focus card is active per workspace.">
+          <div className="space-y-4">
+            {focusCards.map((card) => (
+              <article key={card.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{card.title}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{card.id}</p>
+                  </div>
+                  <StatusBadge>{card.status}</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm leading-6">{card.goal}</p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">workspace {card.workspaceId}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">priority {card.priority}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">{card.timeframe || "no timeframe"}</span>
+                </div>
+                <div className="mt-4">
+                  <FocusCardActivateButton focusCardId={card.id} disabled={card.status === "active"} />
+                </div>
+              </article>
+            ))}
+            {focusCards.length === 0 ? <p className="text-sm text-[var(--muted)]">No focus cards exist yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Capability Signals" description="Evidence-backed signals about what the user appears able to do and where support should adapt.">
+          <div className="space-y-4">
+            {[...acceptedSignals, ...pendingSignals].map((signal) => (
+              <article key={signal.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{signal.topic}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{signal.id}</p>
+                  </div>
+                  <StatusBadge>{signal.status}</StatusBadge>
+                </div>
+                <p className="mt-3 text-sm leading-6">Observed practice: {signal.observedPractice}</p>
+                <p className="mt-2 text-sm text-[var(--muted)]">Current gaps: {signal.currentGaps}</p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">confidence {signal.confidence.toFixed(2)}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">nodes {signal.evidenceNodeIds.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">fragments {signal.evidenceFragmentIds.length}</span>
+                </div>
+              </article>
+            ))}
+            {acceptedSignals.length + pendingSignals.length === 0 ? <p className="text-sm text-[var(--muted)]">No capability signals exist yet.</p> : null}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Mistake Patterns" description="Recurring misunderstandings and blind spots that should shape future AI help.">
+          <div className="space-y-4">
+            {[...acceptedMistakes, ...pendingMistakes].map((mistake) => (
+              <article key={mistake.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{mistake.topic}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{mistake.id}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusBadge>{mistake.status}</StatusBadge>
+                    <StatusBadge>{mistake.privacyLevel}</StatusBadge>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm leading-6">{mistake.description}</p>
+                <p className="mt-2 text-sm text-[var(--muted)]">Fix suggestions: {mistake.fixSuggestions}</p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
+                  <span className="rounded-full bg-black/5 px-3 py-1">recurrence {mistake.recurrenceCount}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">nodes {mistake.exampleNodeIds.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">fragments {mistake.exampleFragmentIds.length}</span>
+                </div>
+              </article>
+            ))}
+            {acceptedMistakes.length + pendingMistakes.length === 0 ? <p className="text-sm text-[var(--muted)]">No mistake patterns exist yet.</p> : null}
+          </div>
+        </SectionCard>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/app/visas/page.tsx
+++ b/apps/web/src/app/visas/page.tsx
@@ -31,7 +31,7 @@ export default async function VisasPage() {
   };
 
   return (
-    <PageShell currentPath="/visas" title="Visas" subtitle="Manage scenario bundles as a live sharing product with policies, access state, and lightweight flowback">
+    <PageShell currentPath="/visas" title="Mount Center" subtitle="Start from a passport, then narrow what an external AI can read through managed visa bundles">
       <section className="grid gap-4 md:grid-cols-4">
         <StatTile label="Total Visas" value={summary.total} />
         <StatTile label="Active Visas" value={summary.active} />
@@ -42,7 +42,7 @@ export default async function VisasPage() {
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <SectionCard
           title="Create Visa Bundle"
-          description="Create a managed read-only scenario bundle with expiry, usage limits, redaction rules, and machine-download policy."
+          description="Begin with the passport context, then narrow nodes, postcards, access limits, and machine-download policy for one specific mount."
         >
           <VisaForm
             passports={passports.map((passport) => ({
@@ -52,7 +52,7 @@ export default async function VisasPage() {
           />
         </SectionCard>
 
-        <SectionCard title="Issued Visas" description="Track current share state, access activity, and pending external flowback.">
+        <SectionCard title="Issued Visas" description="Track current mount state, access activity, and pending external flowback.">
           <div className="space-y-4">
             {visas.map((visa) => (
               <article key={visa.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">

--- a/apps/web/src/components/focus-card-activate-button.tsx
+++ b/apps/web/src/components/focus-card-activate-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export function FocusCardActivateButton(props: { focusCardId: string; disabled?: boolean }) {
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        disabled={props.disabled || isPending}
+        onClick={() => {
+          startTransition(async () => {
+            const response = await fetch(`/api/focus-cards/${props.focusCardId}/activate`, {
+              method: "POST"
+            });
+            const payload = await response.json();
+            setMessage(response.ok ? "Activated" : payload.error ?? "Activation failed");
+          });
+        }}
+        className="rounded-full border border-[var(--line)] px-4 py-2 text-sm disabled:opacity-50"
+      >
+        {isPending ? "Activating..." : "Set Active"}
+      </button>
+      {message ? <span className="text-xs text-[var(--muted)]">{message}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/focus-card-form.tsx
+++ b/apps/web/src/components/focus-card-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export function FocusCardForm(props: {
+  workspaces: Array<{ id: string; title: string; workspaceType: string }>;
+  defaultWorkspaceId?: string;
+}) {
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+
+        startTransition(async () => {
+          const response = await fetch("/api/focus-cards", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              workspaceId: formData.get("workspaceId"),
+              title: formData.get("title"),
+              goal: formData.get("goal"),
+              timeframe: formData.get("timeframe"),
+              priority: formData.get("priority"),
+              successCriteria: formData.get("successCriteria"),
+              relatedTopics: String(formData.get("relatedTopics") ?? "")
+                .split(",")
+                .map((entry) => entry.trim())
+                .filter(Boolean),
+              status: "active"
+            })
+          });
+
+          const payload = await response.json();
+          setMessage(response.ok ? `Created: ${payload.focusCardId}` : payload.error ?? "Focus card creation failed");
+          if (response.ok) {
+            form.reset();
+          }
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2 text-sm">
+          <span>Workspace</span>
+          <select name="workspaceId" defaultValue={props.defaultWorkspaceId ?? props.workspaces[0]?.id ?? ""} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            {props.workspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.title} · {workspace.workspaceType}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Priority</span>
+          <select name="priority" defaultValue="medium" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            <option value="high">high</option>
+            <option value="medium">medium</option>
+            <option value="low">low</option>
+          </select>
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Title</span>
+          <input name="title" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="Current Goal" />
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Timeframe</span>
+          <input name="timeframe" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" placeholder="This week" />
+        </label>
+      </div>
+
+      <label className="space-y-2 text-sm">
+        <span>Goal</span>
+        <textarea name="goal" rows={4} required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+
+      <label className="space-y-2 text-sm">
+        <span>Success Criteria</span>
+        <textarea name="successCriteria" rows={3} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+
+      <label className="space-y-2 text-sm">
+        <span>Related Topics (comma separated)</span>
+        <input name="relatedTopics" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+      </label>
+
+      <div className="flex items-center gap-4">
+        <button disabled={isPending} className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white disabled:opacity-50">
+          {isPending ? "Saving..." : "Create Active Focus"}
+        </button>
+        {message ? <span className="text-sm text-[var(--muted)]">{message}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/import-form.tsx
+++ b/apps/web/src/components/import-form.tsx
@@ -7,7 +7,9 @@ import type { PrivacyLevel, SourceType } from "@ai-knowledge-passport/shared";
 const types: SourceType[] = ["markdown", "txt", "pdf", "url", "image", "chat", "audio"];
 const privacyLevels: PrivacyLevel[] = ["L0_SELF", "L1_LOCAL_AI", "L2_INVITED", "L3_PUBLIC", "L4_AGENT_ONLY"];
 
-export function ImportForm() {
+export function ImportForm(props: {
+  workspaces: Array<{ id: string; title: string; workspaceType: string }>;
+}) {
   const [type, setType] = useState<SourceType>("markdown");
   const [message, setMessage] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -58,6 +60,16 @@ export function ImportForm() {
         <label className="space-y-2 text-sm">
           <span>Title</span>
           <input name="title" required className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+        </label>
+        <label className="space-y-2 text-sm">
+          <span>Workspace</span>
+          <select name="workspaceId" defaultValue={props.workspaces[0]?.id ?? "ws_personal"} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+            {props.workspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.title} · {workspace.workspaceType}
+              </option>
+            ))}
+          </select>
         </label>
         <label className="space-y-2 text-sm">
           <span>Project Key</span>

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,18 +1,23 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Activity, BadgeCheck, BookOpenText, Bot, Database, Download, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, SlidersHorizontal, Waypoints, Workflow } from "lucide-react";
+import { Activity, BadgeCheck, BookOpenText, Bot, Database, Download, FileSearch, Files, HeartPulse, Key, LayoutDashboard, LibraryBig, ScrollText, Shield, SlidersHorizontal, Target, Waypoints, Workflow } from "lucide-react";
 import clsx from "clsx";
 
-const navigation = [
+const coreNavigation = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/inbox", label: "Inbox", icon: Files },
   { href: "/knowledge", label: "Knowledge", icon: LibraryBig },
-  { href: "/review", label: "Review Queue", icon: BadgeCheck },
-  { href: "/research", label: "Research", icon: FileSearch },
-  { href: "/outputs", label: "Outputs", icon: BookOpenText },
+  { href: "/signals", label: "Signals", icon: Target },
   { href: "/postcards", label: "Postcards", icon: Activity },
-  { href: "/visas", label: "Visas", icon: Key },
+  { href: "/passport", label: "Passport", icon: Shield },
+  { href: "/review", label: "Review Queue", icon: BadgeCheck },
+  { href: "/research", label: "Research", icon: FileSearch }
+];
+
+const advancedNavigation = [
+  { href: "/outputs", label: "Outputs", icon: BookOpenText },
+  { href: "/visas", label: "Mount Center", icon: Key },
   { href: "/avatars", label: "Avatars", icon: Bot },
   { href: "/exports", label: "Exports", icon: Download },
   { href: "/policies", label: "Policies", icon: SlidersHorizontal },
@@ -21,7 +26,7 @@ const navigation = [
   { href: "/health", label: "Health Center", icon: HeartPulse },
   { href: "/visuals", label: "Visuals", icon: Waypoints },
   { href: "/audit", label: "Audit Log", icon: ScrollText },
-  { href: "/passport", label: "Passport & Backup", icon: Shield }
+  { href: "/fragments", label: "Fragments", icon: FileSearch }
 ];
 
 export function PageShell(props: { currentPath: string; title: string; subtitle: string; children: ReactNode }) {
@@ -34,40 +39,70 @@ export function PageShell(props: { currentPath: string; title: string; subtitle:
               <Database size={24} />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Local-first</p>
-              <h1 className="mt-1 text-xl font-semibold">AI Knowledge Passport</h1>
+              <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">AI-mountable</p>
+              <h1 className="mt-1 text-xl font-semibold">Knowledge Base</h1>
               <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
-                Raw materials, the local wiki, research outputs, passport snapshots, and backups all stay under local control.
+                Help any AI understand your foundation, current goal, and blind spots under local control and explicit authorization.
               </p>
             </div>
           </div>
 
-          <nav className="space-y-2">
-            {navigation.map((item) => {
-              const Icon = item.icon;
-              const active = props.currentPath === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={clsx(
-                    "flex items-center gap-3 rounded-2xl px-4 py-3 text-sm transition",
-                    active
-                      ? "bg-[var(--accent)] text-white shadow-lg shadow-green-900/20"
-                      : "text-[var(--muted)] hover:bg-white/70 hover:text-[var(--ink)]"
-                  )}
-                >
-                  <Icon size={18} />
-                  <span>{item.label}</span>
-                </Link>
-              );
-            })}
+          <nav className="space-y-6">
+            <div>
+              <p className="mb-2 px-2 text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Core</p>
+              <div className="space-y-2">
+                {coreNavigation.map((item) => {
+                  const Icon = item.icon;
+                  const active = props.currentPath === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={clsx(
+                        "flex items-center gap-3 rounded-2xl px-4 py-3 text-sm transition",
+                        active
+                          ? "bg-[var(--accent)] text-white shadow-lg shadow-green-900/20"
+                          : "text-[var(--muted)] hover:bg-white/70 hover:text-[var(--ink)]"
+                      )}
+                    >
+                      <Icon size={18} />
+                      <span>{item.label}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-2 px-2 text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Advanced</p>
+              <div className="space-y-2">
+                {advancedNavigation.map((item) => {
+                  const Icon = item.icon;
+                  const active = props.currentPath === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={clsx(
+                        "flex items-center gap-3 rounded-2xl px-4 py-3 text-sm transition",
+                        active
+                          ? "bg-[var(--accent)] text-white shadow-lg shadow-green-900/20"
+                          : "text-[var(--muted)] hover:bg-white/70 hover:text-[var(--ink)]"
+                      )}
+                    >
+                      <Icon size={18} />
+                      <span>{item.label}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
           </nav>
 
           <div className="mt-8 rounded-3xl border border-[var(--line)] bg-[var(--surface-strong)] p-4 text-sm text-[var(--muted)]">
-            <p className="font-medium text-[var(--ink)]">MVP Loop</p>
+            <p className="font-medium text-[var(--ink)]">Primary Loop</p>
             <p className="mt-2 leading-6">
-              Import, compile, research, flowback, postcards, passports, and backups all run directly inside this shell.
+              Import, compile, synthesize signals, publish postcards, generate a passport, and mount only what an AI needs.
             </p>
           </div>
         </aside>

--- a/apps/web/src/components/passport-controls.tsx
+++ b/apps/web/src/components/passport-controls.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useTransition } from "react";
 
-export function PassportControls() {
+export function PassportControls(props: {
+  workspaces: Array<{ id: string; title: string; workspaceType: string }>;
+}) {
   const [passportMessage, setPassportMessage] = useState("");
   const [backupMessage, setBackupMessage] = useState("");
   const [isPassportPending, startPassportTransition] = useTransition();
@@ -23,6 +25,7 @@ export function PassportControls() {
               },
               body: JSON.stringify({
                 title: formData.get("title"),
+                workspaceId: formData.get("workspaceId"),
                 includeNodeIds: String(formData.get("includeNodeIds") ?? "")
                   .split(",")
                   .map((entry) => entry.trim())
@@ -43,6 +46,16 @@ export function PassportControls() {
           <label className="space-y-2 text-sm">
             <span>Passport Title</span>
             <input name="title" defaultValue="Knowledge Passport" className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3" />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span>Workspace</span>
+            <select name="workspaceId" defaultValue={props.workspaces[0]?.id ?? "ws_personal"} className="w-full rounded-2xl border border-[var(--line)] bg-white px-4 py-3">
+              {props.workspaces.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>
+                  {workspace.title} · {workspace.workspaceType}
+                </option>
+              ))}
+            </select>
           </label>
           <label className="space-y-2 text-sm">
             <span>Minimum Privacy Floor</span>

--- a/apps/web/src/server/db/init.ts
+++ b/apps/web/src/server/db/init.ts
@@ -28,11 +28,20 @@ export function initializeDatabase() {
 
 export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabase>["sqlite"]) {
   sqlite.exec(`
+    create table if not exists workspaces (
+      id text primary key,
+      title text not null,
+      workspace_type text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+
     create table if not exists sources (
       id text primary key,
       type text not null,
       title text not null,
       origin_url text,
+      workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict,
       created_at text,
       imported_at text not null,
       file_path text,
@@ -73,6 +82,7 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       claim_type text not null,
       title text not null,
       statement text not null,
+      workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict,
       status text not null,
       confidence real not null default 0,
       source_fragment_ids_json text not null default '[]',
@@ -117,6 +127,7 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       title text not null,
       summary text not null,
       body_md text not null,
+      workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict,
       status text not null,
       source_ids_json text not null default '[]',
       tags_json text not null default '[]',
@@ -150,6 +161,7 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
       id text primary key,
       card_type text not null,
       title text not null,
+      workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict,
       claim text not null,
       evidence_summary text not null,
       user_view text not null,
@@ -164,12 +176,56 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
     create table if not exists passport_snapshots (
       id text primary key,
       title text not null,
+      workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict,
       human_markdown text not null,
       machine_manifest_json text not null,
       include_node_ids_json text not null default '[]',
       include_postcard_ids_json text not null default '[]',
       privacy_floor text not null,
       created_at text not null
+    );
+
+    create table if not exists capability_signals (
+      id text primary key,
+      workspace_id text not null references workspaces(id) on delete cascade,
+      topic text not null,
+      observed_practice text not null,
+      current_gaps text not null,
+      confidence real not null default 0,
+      evidence_node_ids_json text not null default '[]',
+      evidence_fragment_ids_json text not null default '[]',
+      status text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+
+    create table if not exists mistake_patterns (
+      id text primary key,
+      workspace_id text not null references workspaces(id) on delete cascade,
+      topic text not null,
+      description text not null,
+      fix_suggestions text not null,
+      recurrence_count integer not null default 1,
+      example_node_ids_json text not null default '[]',
+      example_fragment_ids_json text not null default '[]',
+      privacy_level text not null,
+      status text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+
+    create table if not exists focus_cards (
+      id text primary key,
+      workspace_id text not null references workspaces(id) on delete cascade,
+      title text not null,
+      goal text not null,
+      timeframe text not null default '',
+      priority text not null default 'medium',
+      success_criteria text not null default '',
+      related_topics_json text not null default '[]',
+      status text not null,
+      created_at text not null,
+      updated_at text not null
     );
 
     create table if not exists visa_bundles (
@@ -390,6 +446,11 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
     );
   `);
 
+  sqlite.exec(`
+    insert or ignore into workspaces (id, title, workspace_type, created_at, updated_at)
+    values ('ws_personal', 'Personal', 'personal', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  `);
+
   const sourceFragmentCount = sqlite
     .prepare("select count(*) as count from source_fragments_fts")
     .get() as { count?: number } | undefined;
@@ -417,5 +478,18 @@ export function initializeDatabaseForSqlite(sqlite: ReturnType<typeof getDatabas
   ensureColumn(sqlite, "visa_bundles", "max_access_count", "max_access_count integer");
   ensureColumn(sqlite, "visa_bundles", "machine_download_count", "machine_download_count integer not null default 0");
   ensureColumn(sqlite, "visa_bundles", "max_machine_downloads", "max_machine_downloads integer");
+  ensureColumn(sqlite, "sources", "workspace_id", "workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict");
+  ensureColumn(sqlite, "claims", "workspace_id", "workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict");
+  ensureColumn(sqlite, "wiki_nodes", "workspace_id", "workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict");
+  ensureColumn(sqlite, "postcards", "workspace_id", "workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict");
+  ensureColumn(sqlite, "passport_snapshots", "workspace_id", "workspace_id text not null default 'ws_personal' references workspaces(id) on delete restrict");
+
+  sqlite.exec(`
+    update sources set workspace_id = 'ws_personal' where workspace_id is null or workspace_id = '';
+    update claims set workspace_id = 'ws_personal' where workspace_id is null or workspace_id = '';
+    update wiki_nodes set workspace_id = 'ws_personal' where workspace_id is null or workspace_id = '';
+    update postcards set workspace_id = 'ws_personal' where workspace_id is null or workspace_id = '';
+    update passport_snapshots set workspace_id = 'ws_personal' where workspace_id is null or workspace_id = '';
+  `);
 
 }

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -6,11 +6,20 @@ import {
   text
 } from "drizzle-orm/sqlite-core";
 
+export const workspaces = sqliteTable("workspaces", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  workspaceType: text("workspace_type").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
 export const sources = sqliteTable("sources", {
   id: text("id").primaryKey(),
   type: text("type").notNull(),
   title: text("title").notNull(),
   originUrl: text("origin_url"),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "restrict" }),
   createdAt: text("created_at"),
   importedAt: text("imported_at").notNull(),
   filePath: text("file_path"),
@@ -51,6 +60,7 @@ export const claims = sqliteTable("claims", {
   claimType: text("claim_type").notNull(),
   title: text("title").notNull(),
   statement: text("statement").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "restrict" }),
   status: text("status").notNull(),
   confidence: real("confidence").notNull().default(0),
   sourceFragmentIdsJson: text("source_fragment_ids_json").notNull().default("[]"),
@@ -95,6 +105,7 @@ export const wikiNodes = sqliteTable("wiki_nodes", {
   title: text("title").notNull(),
   summary: text("summary").notNull(),
   bodyMd: text("body_md").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "restrict" }),
   status: text("status").notNull(),
   sourceIdsJson: text("source_ids_json").notNull().default("[]"),
   tagsJson: text("tags_json").notNull().default("[]"),
@@ -128,6 +139,7 @@ export const postcards = sqliteTable("postcards", {
   id: text("id").primaryKey(),
   cardType: text("card_type").notNull(),
   title: text("title").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "restrict" }),
   claim: text("claim").notNull(),
   evidenceSummary: text("evidence_summary").notNull(),
   userView: text("user_view").notNull(),
@@ -142,12 +154,56 @@ export const postcards = sqliteTable("postcards", {
 export const passportSnapshots = sqliteTable("passport_snapshots", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "restrict" }),
   humanMarkdown: text("human_markdown").notNull(),
   machineManifestJson: text("machine_manifest_json").notNull(),
   includeNodeIdsJson: text("include_node_ids_json").notNull().default("[]"),
   includePostcardIdsJson: text("include_postcard_ids_json").notNull().default("[]"),
   privacyFloor: text("privacy_floor").notNull(),
   createdAt: text("created_at").notNull()
+});
+
+export const capabilitySignals = sqliteTable("capability_signals", {
+  id: text("id").primaryKey(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  topic: text("topic").notNull(),
+  observedPractice: text("observed_practice").notNull(),
+  currentGaps: text("current_gaps").notNull(),
+  confidence: real("confidence").notNull().default(0),
+  evidenceNodeIdsJson: text("evidence_node_ids_json").notNull().default("[]"),
+  evidenceFragmentIdsJson: text("evidence_fragment_ids_json").notNull().default("[]"),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const mistakePatterns = sqliteTable("mistake_patterns", {
+  id: text("id").primaryKey(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  topic: text("topic").notNull(),
+  description: text("description").notNull(),
+  fixSuggestions: text("fix_suggestions").notNull(),
+  recurrenceCount: integer("recurrence_count").notNull().default(1),
+  exampleNodeIdsJson: text("example_node_ids_json").notNull().default("[]"),
+  exampleFragmentIdsJson: text("example_fragment_ids_json").notNull().default("[]"),
+  privacyLevel: text("privacy_level").notNull(),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const focusCards = sqliteTable("focus_cards", {
+  id: text("id").primaryKey(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  goal: text("goal").notNull(),
+  timeframe: text("timeframe").notNull().default(""),
+  priority: text("priority").notNull().default("medium"),
+  successCriteria: text("success_criteria").notNull().default(""),
+  relatedTopicsJson: text("related_topics_json").notNull().default("[]"),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
 });
 
 export const visaBundles = sqliteTable("visa_bundles", {

--- a/apps/web/src/server/providers/model-provider.ts
+++ b/apps/web/src/server/providers/model-provider.ts
@@ -70,10 +70,36 @@ export interface ModelProvider {
     title: string;
     nodes: Array<{ title: string; summary: string; bodyMd: string; tags: string[] }>;
     postcards: Array<{ title: string; claim: string; userView: string; cardType: PostcardType }>;
+    capabilitySignals: Array<{ topic: string; observedPractice: string; currentGaps: string; confidence: number }>;
+    mistakePatterns: Array<{ topic: string; description: string; fixSuggestions: string; recurrenceCount: number }>;
+    focusCard: { title: string; goal: string; timeframe: string; priority: string; successCriteria: string } | null;
     privacyFloor: PrivacyLevel;
   }): Promise<{
     humanMarkdown: string;
     machineManifest: Record<string, unknown>;
+  }>;
+  generateLearnerState(input: {
+    workspaceTitle: string;
+    nodes: Array<{ id: string; title: string; summary: string; bodyMd: string; tags: string[]; projectKey?: string | null }>;
+    claims: Array<{ id: string; title: string; statement: string; confidence: number; tags: string[]; sourceFragmentIds: string[]; nodeId?: string | null }>;
+  }): Promise<{
+    capabilitySignals: Array<{
+      topic: string;
+      observedPractice: string;
+      currentGaps: string;
+      confidence: number;
+      evidenceNodeIds: string[];
+      evidenceFragmentIds: string[];
+    }>;
+    mistakePatterns: Array<{
+      topic: string;
+      description: string;
+      fixSuggestions: string;
+      recurrenceCount: number;
+      exampleNodeIds: string[];
+      exampleFragmentIds: string[];
+      privacyLevel: PrivacyLevel;
+    }>;
   }>;
   generateAvatarReply(input: {
     avatarTitle: string;

--- a/apps/web/src/server/providers/openai-provider.ts
+++ b/apps/web/src/server/providers/openai-provider.ts
@@ -246,6 +246,9 @@ export class OpenAIProvider implements ModelProvider {
     title: string;
     nodes: Array<{ title: string; summary: string; bodyMd: string; tags: string[] }>;
     postcards: Array<{ title: string; claim: string; userView: string; cardType: "knowledge" | "project" | "method" | "question" }>;
+    capabilitySignals: Array<{ topic: string; observedPractice: string; currentGaps: string; confidence: number }>;
+    mistakePatterns: Array<{ topic: string; description: string; fixSuggestions: string; recurrenceCount: number }>;
+    focusCard: { title: string; goal: string; timeframe: string; priority: string; successCriteria: string } | null;
     privacyFloor: "L0_SELF" | "L1_LOCAL_AI" | "L2_INVITED" | "L3_PUBLIC" | "L4_AGENT_ONLY";
   }) {
     const response = await this.jsonResponse<{
@@ -261,6 +264,79 @@ export class OpenAIProvider implements ModelProvider {
       machineManifest: response.machineManifest && typeof response.machineManifest === "object"
         ? (response.machineManifest as Record<string, unknown>)
         : {}
+    };
+  }
+
+  async generateLearnerState(input: {
+    workspaceTitle: string;
+    nodes: Array<{ id: string; title: string; summary: string; bodyMd: string; tags: string[]; projectKey?: string | null }>;
+    claims: Array<{ id: string; title: string; statement: string; confidence: number; tags: string[]; sourceFragmentIds: string[]; nodeId?: string | null }>;
+  }) {
+    const response = await this.jsonResponse<{
+      capabilitySignals?: unknown;
+      mistakePatterns?: unknown;
+    }>(
+      "You are synthesizing a user's current learning state. Extract conservative, evidence-backed capability signals and recurring mistake patterns. Never claim certainty or assign ability scores. Use only node ids and source fragment ids that appear in the provided payload.",
+      input
+    );
+
+    const capabilitySignals = Array.isArray(response.capabilitySignals)
+      ? response.capabilitySignals.flatMap((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return [];
+          }
+          const candidate = entry as Record<string, unknown>;
+          const topic = typeof candidate.topic === "string" ? candidate.topic.trim() : "";
+          const observedPractice = typeof candidate.observedPractice === "string" ? candidate.observedPractice.trim() : "";
+          const currentGaps = typeof candidate.currentGaps === "string" ? candidate.currentGaps.trim() : "";
+          const confidence = typeof candidate.confidence === "number" ? candidate.confidence : 0.5;
+
+          if (!topic || !observedPractice || !currentGaps) {
+            return [];
+          }
+
+          return [{
+            topic,
+            observedPractice,
+            currentGaps,
+            confidence: Math.max(0, Math.min(1, confidence)),
+            evidenceNodeIds: toArrayOfStrings(candidate.evidenceNodeIds),
+            evidenceFragmentIds: toArrayOfStrings(candidate.evidenceFragmentIds)
+          }];
+        })
+      : [];
+
+    const mistakePatterns = Array.isArray(response.mistakePatterns)
+      ? response.mistakePatterns.flatMap((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return [];
+          }
+          const candidate = entry as Record<string, unknown>;
+          const topic = typeof candidate.topic === "string" ? candidate.topic.trim() : "";
+          const description = typeof candidate.description === "string" ? candidate.description.trim() : "";
+          const fixSuggestions = typeof candidate.fixSuggestions === "string" ? candidate.fixSuggestions.trim() : "";
+          const recurrenceCount = typeof candidate.recurrenceCount === "number" ? Math.max(1, Math.floor(candidate.recurrenceCount)) : 1;
+          const privacyLevel = typeof candidate.privacyLevel === "string" ? candidate.privacyLevel : "L1_LOCAL_AI";
+
+          if (!topic || !description || !fixSuggestions) {
+            return [];
+          }
+
+          return [{
+            topic,
+            description,
+            fixSuggestions,
+            recurrenceCount,
+            exampleNodeIds: toArrayOfStrings(candidate.exampleNodeIds),
+            exampleFragmentIds: toArrayOfStrings(candidate.exampleFragmentIds),
+            privacyLevel: privacyLevel as "L0_SELF" | "L1_LOCAL_AI" | "L2_INVITED" | "L3_PUBLIC" | "L4_AGENT_ONLY"
+          }];
+        })
+      : [];
+
+    return {
+      capabilitySignals,
+      mistakePatterns
     };
   }
 

--- a/apps/web/src/server/services/agent-packs.ts
+++ b/apps/web/src/server/services/agent-packs.ts
@@ -9,6 +9,7 @@ import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray } from "./common";
 import { assertPolicyAllows } from "./policies";
 import { canIncludeInPassport } from "./privacy";
+import { getPassportSnapshot } from "./passports";
 
 type PackNode = {
   id: string;
@@ -30,6 +31,7 @@ function buildAgentPackHumanMarkdown(input: {
   title: string;
   sourcePassportId: string | null;
   sourceVisaId: string | null;
+  passportContext: { focusCard?: { title?: string } | null; capabilitySignals?: unknown[]; mistakePatterns?: unknown[] } | null;
   nodes: PackNode[];
   postcards: PackPostcard[];
 }) {
@@ -39,6 +41,15 @@ function buildAgentPackHumanMarkdown(input: {
     `Source passport: ${input.sourcePassportId ?? "none"}`,
     `Source visa: ${input.sourceVisaId ?? "none"}`
   ];
+
+  if (input.passportContext) {
+    lines.push(
+      "",
+      `Inherited focus: ${input.passportContext.focusCard?.title ?? "none"}`,
+      `Inherited capability signals: ${Array.isArray(input.passportContext.capabilitySignals) ? input.passportContext.capabilitySignals.length : 0}`,
+      `Inherited mistake patterns: ${Array.isArray(input.passportContext.mistakePatterns) ? input.passportContext.mistakePatterns.length : 0}`
+    );
+  }
 
   if (input.postcards.length) {
     lines.push("", "## Postcards");
@@ -71,6 +82,7 @@ function buildAgentPackMachineManifest(input: {
   sourcePassportId: string | null;
   sourceVisaId: string | null;
   privacyFloor: PrivacyLevel;
+  passportContext: Record<string, unknown> | null;
   nodes: PackNode[];
   postcards: PackPostcard[];
 }) {
@@ -81,6 +93,7 @@ function buildAgentPackMachineManifest(input: {
     sourcePassportId: input.sourcePassportId,
     sourceVisaId: input.sourceVisaId,
     privacyFloor: input.privacyFloor,
+    passportContext: input.passportContext,
     stats: {
       nodeCount: input.nodes.length,
       postcardCount: input.postcards.length
@@ -233,10 +246,19 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
   }
 
   const packId = createId("pack");
+  const sourcePassport = resolved.sourcePassportId ? await getPassportSnapshot(context, resolved.sourcePassportId) : null;
+  const passportContext = sourcePassport?.machineManifest && typeof sourcePassport.machineManifest === "object"
+    ? {
+        focusCard: (sourcePassport.machineManifest as { focusCard?: unknown }).focusCard ?? null,
+        capabilitySignals: (sourcePassport.machineManifest as { capabilitySignals?: unknown[] }).capabilitySignals ?? [],
+        mistakePatterns: (sourcePassport.machineManifest as { mistakePatterns?: unknown[] }).mistakePatterns ?? []
+      }
+    : null;
   const humanMarkdown = buildAgentPackHumanMarkdown({
     title: input.title,
     sourcePassportId: resolved.sourcePassportId,
     sourceVisaId: resolved.sourceVisaId,
+    passportContext,
     nodes,
     postcards: cards
   });
@@ -246,6 +268,7 @@ export async function createAgentPackSnapshot(context: AppContext, input: AgentP
     sourcePassportId: resolved.sourcePassportId,
     sourceVisaId: resolved.sourceVisaId,
     privacyFloor: effectivePrivacyFloor,
+    passportContext,
     nodes,
     postcards: cards
   });

--- a/apps/web/src/server/services/avatar-governance.ts
+++ b/apps/web/src/server/services/avatar-governance.ts
@@ -28,6 +28,7 @@ export type PackEvidenceItem = {
   id: string;
   title: string;
   text: string;
+  workspaceId?: string;
 };
 
 export type AvatarQuestionClassification = {
@@ -78,7 +79,8 @@ export async function resolvePackEvidence(context: AppContext, pack: AgentPackSn
     .map((node) => ({
       id: node.id,
       title: node.title,
-      text: `${node.title}\n${node.summary}\n${node.bodyMd}`
+      text: `${node.title}\n${node.summary}\n${node.bodyMd}`,
+      workspaceId: node.workspaceId
     }));
 }
 

--- a/apps/web/src/server/services/avatar-live-sessions.ts
+++ b/apps/web/src/server/services/avatar-live-sessions.ts
@@ -24,6 +24,7 @@ import { getAvatarProfile } from "./avatars";
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray } from "./common";
 import { resolveObjectPolicy } from "./policies";
+import { buildWorkspaceContextBlock } from "./signals";
 
 type AvatarLiveSessionRow = typeof avatarLiveSessions.$inferSelect;
 type AvatarLiveMessageRow = typeof avatarLiveMessages.$inferSelect;
@@ -305,6 +306,7 @@ export async function postAvatarLiveMessage(
   }
 
   const scopedEvidence = await resolvePackEvidence(context, pack);
+  const contextWorkspaceId = scopedEvidence.map((entry) => entry.workspaceId).find(Boolean) ?? null;
   const classification = classifyAvatarQuestion(avatar, scopedEvidence, input.contentMd);
 
   const transcriptSnapshot = await getAvatarLiveSession(context, sessionId);
@@ -376,7 +378,10 @@ export async function postAvatarLiveMessage(
     avatarTitle: avatar.title,
     intro: avatar.intro,
     toneRules: avatar.toneRules,
-    question: buildAvatarPromptQuestion(transcript, input.contentMd),
+    question: [
+      await buildWorkspaceContextBlock(context, contextWorkspaceId),
+      buildAvatarPromptQuestion(transcript, input.contentMd)
+    ].filter(Boolean).join("\n\n"),
     evidence: classification.evidence.map((entry) => ({
       refId: entry.id,
       title: entry.title,

--- a/apps/web/src/server/services/avatars.ts
+++ b/apps/web/src/server/services/avatars.ts
@@ -25,6 +25,7 @@ import { createId, nowIso, parseJsonArray, parseJsonObject } from "./common";
 import { getAgentPackSnapshot } from "./agent-packs";
 import { assertPolicyAllows, resolveObjectPolicy } from "./policies";
 import { buildAvatarPromptQuestion, classifyAvatarQuestion, resolvePackEvidence } from "./avatar-governance";
+import { buildWorkspaceContextBlock } from "./signals";
 
 type AvatarProfileRow = typeof avatarProfiles.$inferSelect;
 type AvatarSimulationSessionRow = typeof avatarSimulationSessions.$inferSelect;
@@ -319,6 +320,7 @@ export async function simulateAvatar(context: AppContext, avatarId: string, inpu
   }
 
   const scopedEvidence = await resolvePackEvidence(context, pack);
+  const contextWorkspaceId = scopedEvidence.map((entry) => entry.workspaceId).find(Boolean) ?? null;
   const classification = classifyAvatarQuestion(profile, scopedEvidence, input.question);
 
   if (classification.kind !== "answered") {
@@ -367,7 +369,10 @@ export async function simulateAvatar(context: AppContext, avatarId: string, inpu
     avatarTitle: profile.title,
     intro: profile.intro,
     toneRules: profile.toneRules,
-    question: buildAvatarPromptQuestion([], input.question),
+    question: [
+      await buildWorkspaceContextBlock(context, contextWorkspaceId),
+      buildAvatarPromptQuestion([], input.question)
+    ].filter(Boolean).join("\n\n"),
     evidence: classification.evidence.map((entry) => ({
       refId: entry.id,
       title: entry.title,

--- a/apps/web/src/server/services/claims.ts
+++ b/apps/web/src/server/services/claims.ts
@@ -10,6 +10,7 @@ export async function createClaim(
     claimType: string;
     title: string;
     statement: string;
+    workspaceId?: string;
     status?: string;
     confidence?: number;
     sourceFragmentIds?: string[];
@@ -25,6 +26,7 @@ export async function createClaim(
     claimType: input.claimType,
     title: input.title,
     statement: input.statement,
+    workspaceId: input.workspaceId ?? "ws_personal",
     status: input.status ?? "candidate",
     confidence: input.confidence ?? 0,
     sourceFragmentIdsJson: JSON.stringify(input.sourceFragmentIds ?? []),

--- a/apps/web/src/server/services/compiler.ts
+++ b/apps/web/src/server/services/compiler.ts
@@ -9,6 +9,7 @@ import { createClaim } from "./claims";
 import { completeCompilationRun, createCompilationRun } from "./compilation-runs";
 import { createId, nowIso, parseJsonArray } from "./common";
 import { deleteWikiNodeFts, syncWikiNodeFts } from "./fts";
+import { generateLearnerStateForWorkspace } from "./signals";
 
 type ExistingNodeRecord = {
   id: string;
@@ -185,6 +186,7 @@ export async function compileSource(context: AppContext, sourceId: string) {
         title: node.title,
         summary: node.summary,
         bodyMd: node.bodyMd,
+        workspaceId: source.workspaceId,
         status: "pending_review",
         sourceIdsJson: JSON.stringify([sourceId]),
         tagsJson: JSON.stringify(node.tags),
@@ -329,6 +331,7 @@ export async function compileSource(context: AppContext, sourceId: string) {
         claimType: "summary_claim",
         title: dbNode.title,
         statement: dbNode.summary,
+        workspaceId: dbNode.workspaceId,
         confidence: strongest[0]?.score ?? 0,
         sourceFragmentIds: strongest.map((entry) => entry.fragmentId),
         sourceIds: parseJsonArray<string>(dbNode.sourceIdsJson),
@@ -550,6 +553,10 @@ export async function applyReviewAction(
     result: "succeeded",
     notes: input.note ?? ""
   });
+
+  if (input.action === "accept" || input.action === "merge") {
+    await generateLearnerStateForWorkspace(context, node.workspaceId);
+  }
 
   return auditId;
 }

--- a/apps/web/src/server/services/dashboard.ts
+++ b/apps/web/src/server/services/dashboard.ts
@@ -1,7 +1,8 @@
 import { desc, eq, sql } from "drizzle-orm";
 
 import type { AppContext } from "@/server/context";
-import { backupRuns, outputs, passportSnapshots, researchSessions, sources, wikiNodes } from "@/server/db/schema";
+import { backupRuns, capabilitySignals, focusCards, mistakePatterns, outputs, passportSnapshots, researchSessions, sources, wikiNodes } from "@/server/db/schema";
+import { defaultWorkspaceId } from "./workspaces";
 
 export async function getDashboardStats(context: AppContext) {
   const today = new Date().toISOString().slice(0, 10);
@@ -38,6 +39,23 @@ export async function getDashboardStats(context: AppContext) {
     orderBy: [desc(backupRuns.createdAt)]
   });
 
+  const [activeFocusCard, topSignals, pendingMistakes] = await Promise.all([
+    context.db.query.focusCards.findFirst({
+      where: sql`${focusCards.workspaceId} = ${defaultWorkspaceId} and ${focusCards.status} = 'active'`,
+      orderBy: [desc(focusCards.updatedAt)]
+    }),
+    context.db.query.capabilitySignals.findMany({
+      where: sql`${capabilitySignals.workspaceId} = ${defaultWorkspaceId} and ${capabilitySignals.status} = 'accepted'`,
+      orderBy: [desc(capabilitySignals.updatedAt)],
+      limit: 3
+    }),
+    context.db.query.mistakePatterns.findMany({
+      where: sql`${mistakePatterns.workspaceId} = ${defaultWorkspaceId} and ${mistakePatterns.status} = 'pending_review'`,
+      orderBy: [desc(mistakePatterns.updatedAt)],
+      limit: 3
+    })
+  ]);
+
   return {
     importsToday: importsTodayRow[0]?.count ?? 0,
     pendingCompile: pendingCompileRow[0]?.count ?? 0,
@@ -45,6 +63,9 @@ export async function getDashboardStats(context: AppContext) {
     recentOutputs,
     recentResearch,
     latestPassport,
-    latestBackup
+    latestBackup,
+    activeFocusCard,
+    topSignals,
+    pendingMistakes
   };
 }

--- a/apps/web/src/server/services/exports.ts
+++ b/apps/web/src/server/services/exports.ts
@@ -116,6 +116,7 @@ function buildManifest(input: {
   objectId: string;
   title: string;
   privacyFloor: string;
+  passportContext: Record<string, unknown> | null;
   includeAvatarProfile: boolean;
   avatarProfileId: string | null;
   nodeCount: number;
@@ -131,6 +132,7 @@ function buildManifest(input: {
     title: input.title,
     createdAt: nowIso(),
     privacyFloor: input.privacyFloor,
+    passportContext: input.passportContext,
     boundaries: {
       internalOnly: true,
       liveAgentCapable: false,
@@ -221,6 +223,10 @@ export async function createAgentPackExportPackage(context: AppContext, input: A
     objectId: resolved.pack.id,
     title: resolved.pack.title,
     privacyFloor: resolved.pack.privacyFloor,
+    passportContext:
+      resolved.pack.machineManifest && typeof resolved.pack.machineManifest === "object"
+        ? ((resolved.pack.machineManifest as { passportContext?: Record<string, unknown> }).passportContext ?? null)
+        : null,
     includeAvatarProfile: Boolean(resolved.avatar),
     avatarProfileId: resolved.avatar?.id ?? null,
     nodeCount: resolved.nodes.length,

--- a/apps/web/src/server/services/focus-cards.ts
+++ b/apps/web/src/server/services/focus-cards.ts
@@ -1,0 +1,127 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import type { FocusCard, FocusCardCreateInput } from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import { focusCards } from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso, parseJsonArray } from "./common";
+import { getWorkspace } from "./workspaces";
+
+function parseFocusCard(row: typeof focusCards.$inferSelect): FocusCard {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    title: row.title,
+    goal: row.goal,
+    timeframe: row.timeframe,
+    priority: row.priority,
+    successCriteria: row.successCriteria,
+    relatedTopics: parseJsonArray<string>(row.relatedTopicsJson),
+    status: row.status as FocusCard["status"],
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+export async function listFocusCards(context: AppContext, workspaceId?: string) {
+  const workspace = await getWorkspace(context, workspaceId);
+  const rows = await context.db.query.focusCards.findMany({
+    where: eq(focusCards.workspaceId, workspace.id),
+    orderBy: [desc(focusCards.updatedAt)]
+  });
+  return rows.map(parseFocusCard);
+}
+
+export async function getActiveFocusCard(context: AppContext, workspaceId?: string) {
+  const workspace = await getWorkspace(context, workspaceId);
+  const row = await context.db.query.focusCards.findFirst({
+    where: and(eq(focusCards.workspaceId, workspace.id), eq(focusCards.status, "active")),
+    orderBy: [desc(focusCards.updatedAt)]
+  });
+
+  return row ? parseFocusCard(row) : null;
+}
+
+export async function createFocusCard(context: AppContext, input: FocusCardCreateInput) {
+  const workspace = await getWorkspace(context, input.workspaceId);
+  const focusCardId = createId("focus");
+  const timestamp = nowIso();
+
+  if (input.status === "active") {
+    await context.db
+      .update(focusCards)
+      .set({
+        status: "archived",
+        updatedAt: timestamp
+      })
+      .where(and(eq(focusCards.workspaceId, workspace.id), eq(focusCards.status, "active")));
+  }
+
+  await context.db.insert(focusCards).values({
+    id: focusCardId,
+    workspaceId: workspace.id,
+    title: input.title,
+    goal: input.goal,
+    timeframe: input.timeframe,
+    priority: input.priority,
+    successCriteria: input.successCriteria,
+    relatedTopicsJson: JSON.stringify(input.relatedTopics),
+    status: input.status,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_focus_card",
+    objectType: "focus_card",
+    objectId: focusCardId,
+    result: "succeeded",
+    notes: input.title
+  });
+
+  return {
+    focusCardId,
+    auditId
+  };
+}
+
+export async function activateFocusCard(context: AppContext, focusCardId: string) {
+  const row = await context.db.query.focusCards.findFirst({
+    where: eq(focusCards.id, focusCardId)
+  });
+
+  if (!row) {
+    throw new Error("Focus card not found.");
+  }
+
+  const timestamp = nowIso();
+  await context.db
+    .update(focusCards)
+    .set({
+      status: "archived",
+      updatedAt: timestamp
+    })
+    .where(and(eq(focusCards.workspaceId, row.workspaceId), eq(focusCards.status, "active")));
+
+  await context.db
+    .update(focusCards)
+    .set({
+      status: "active",
+      updatedAt: timestamp
+    })
+    .where(eq(focusCards.id, focusCardId));
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "activate_focus_card",
+    objectType: "focus_card",
+    objectId: focusCardId,
+    result: "succeeded"
+  });
+
+  return {
+    focusCardId,
+    auditId
+  };
+}

--- a/apps/web/src/server/services/outputs.ts
+++ b/apps/web/src/server/services/outputs.ts
@@ -8,6 +8,7 @@ import { outputs, wikiNodes } from "@/server/db/schema";
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray } from "./common";
 import { syncWikiNodeFts } from "./fts";
+import { defaultWorkspaceId } from "./workspaces";
 
 export async function createOutput(context: AppContext, input: OutputCreateInput) {
   const outputId = createId("out");
@@ -24,6 +25,13 @@ export async function createOutput(context: AppContext, input: OutputCreateInput
   });
 
   let flowbackNodeId: string | null = null;
+  const relatedWorkspaceId = input.relatedNodeIds.length
+    ? (
+        await context.db.query.wikiNodes.findFirst({
+          where: eq(wikiNodes.id, input.relatedNodeIds[0] ?? "")
+        })
+      )?.workspaceId ?? defaultWorkspaceId
+    : defaultWorkspaceId;
 
   if (input.flowbackMode === "new_node") {
     flowbackNodeId = createId("node");
@@ -33,6 +41,7 @@ export async function createOutput(context: AppContext, input: OutputCreateInput
       title: input.title,
       summary: input.content.split("\n").slice(0, 3).join(" ").slice(0, 280),
       bodyMd: input.content,
+      workspaceId: relatedWorkspaceId,
       status: "accepted",
       sourceIdsJson: JSON.stringify(input.relatedSourceIds),
       tagsJson: JSON.stringify([]),

--- a/apps/web/src/server/services/passports.ts
+++ b/apps/web/src/server/services/passports.ts
@@ -7,8 +7,11 @@ import { passportSnapshots, postcards, wikiNodes } from "@/server/db/schema";
 
 import { writeAuditLog } from "./audit";
 import { createId, nowIso, parseJsonArray } from "./common";
+import { getActiveFocusCard } from "./focus-cards";
 import { enqueueJob, maybeRunInlineJobs } from "./jobs";
 import { canIncludeInPassport } from "./privacy";
+import { listCapabilitySignals, listMistakePatterns } from "./signals";
+import { getWorkspace } from "./workspaces";
 
 function buildThemeMap(tags: string[]) {
   return Array.from(new Set(tags.filter(Boolean))).sort();
@@ -17,6 +20,7 @@ function buildThemeMap(tags: string[]) {
 function buildMachineManifest(input: {
   passportId: string;
   title: string;
+  workspaceId: string;
   privacyFloor: PrivacyLevel;
   nodes: Array<{
     id: string;
@@ -34,6 +38,30 @@ function buildMachineManifest(input: {
     privacyLevel: string;
     relatedNodeIds: string[];
   }>;
+  capabilitySignals: Array<{
+    id: string;
+    topic: string;
+    observedPractice: string;
+    currentGaps: string;
+    confidence: number;
+  }>;
+  mistakePatterns: Array<{
+    id: string;
+    topic: string;
+    description: string;
+    fixSuggestions: string;
+    recurrenceCount: number;
+    privacyLevel: string;
+  }>;
+  focusCard: {
+    id: string;
+    title: string;
+    goal: string;
+    timeframe: string;
+    priority: string;
+    successCriteria: string;
+    relatedTopics: string[];
+  } | null;
   aiSummary: Record<string, unknown>;
 }) {
   const allTags = input.nodes.flatMap((node) => node.tags);
@@ -41,11 +69,15 @@ function buildMachineManifest(input: {
     passportId: input.passportId,
     title: input.title,
     generatedAt: nowIso(),
+    workspaceId: input.workspaceId,
     privacyFloor: input.privacyFloor,
     themeMap: buildThemeMap(allTags),
     stats: {
       nodeCount: input.nodes.length,
-      postcardCount: input.postcards.length
+      postcardCount: input.postcards.length,
+      capabilitySignalCount: input.capabilitySignals.length,
+      mistakePatternCount: input.mistakePatterns.length,
+      hasActiveFocusCard: Boolean(input.focusCard)
     },
     nodes: input.nodes.map((node) => ({
       id: node.id,
@@ -63,6 +95,22 @@ function buildMachineManifest(input: {
       privacyLevel: card.privacyLevel,
       relatedNodeIds: card.relatedNodeIds
     })),
+    capabilitySignals: input.capabilitySignals.map((signal) => ({
+      id: signal.id,
+      topic: signal.topic,
+      observedPractice: signal.observedPractice,
+      currentGaps: signal.currentGaps,
+      confidence: signal.confidence
+    })),
+    mistakePatterns: input.mistakePatterns.map((mistake) => ({
+      id: mistake.id,
+      topic: mistake.topic,
+      description: mistake.description,
+      fixSuggestions: mistake.fixSuggestions,
+      recurrenceCount: mistake.recurrenceCount,
+      privacyLevel: mistake.privacyLevel
+    })),
+    focusCard: input.focusCard,
     aiSummary: input.aiSummary
   };
 }
@@ -94,12 +142,13 @@ export async function createPassportSnapshot(context: AppContext, input: Record<
   }
 
   const payload = input as PassportGenerateInput;
+  const workspace = await getWorkspace(context, payload.workspaceId);
   const allNodes = payload.includeNodeIds.length
     ? await context.db.query.wikiNodes.findMany({
         where: inArray(wikiNodes.id, payload.includeNodeIds)
       })
     : await context.db.query.wikiNodes.findMany({
-        where: eq(wikiNodes.status, "accepted")
+        where: eq(wikiNodes.workspaceId, workspace.id)
       });
 
   const allCards = payload.includePostcardIds.length
@@ -109,11 +158,17 @@ export async function createPassportSnapshot(context: AppContext, input: Record<
     : await context.db.query.postcards.findMany();
 
   const nodes = allNodes.filter((node) =>
-    canIncludeInPassport(node.privacyLevel as PrivacyLevel, payload.privacyFloor)
+    node.workspaceId === workspace.id && node.status === "accepted" && canIncludeInPassport(node.privacyLevel as PrivacyLevel, payload.privacyFloor)
   );
   const cards = allCards.filter((card) =>
-    canIncludeInPassport(card.privacyLevel as PrivacyLevel, payload.privacyFloor)
+    card.workspaceId === workspace.id && canIncludeInPassport(card.privacyLevel as PrivacyLevel, payload.privacyFloor)
   );
+
+  const [acceptedSignals, acceptedMistakes, activeFocusCard] = await Promise.all([
+    listCapabilitySignals(context, { workspaceId: workspace.id, status: "accepted", limit: 20 }),
+    listMistakePatterns(context, { workspaceId: workspace.id, status: "accepted", limit: 20 }),
+    getActiveFocusCard(context, workspace.id)
+  ]);
 
   const generated = await context.provider.generatePassport({
     title: payload.title,
@@ -129,6 +184,27 @@ export async function createPassportSnapshot(context: AppContext, input: Record<
       userView: card.userView,
       cardType: card.cardType as never
     })),
+    capabilitySignals: acceptedSignals.map((signal) => ({
+      topic: signal.topic,
+      observedPractice: signal.observedPractice,
+      currentGaps: signal.currentGaps,
+      confidence: signal.confidence
+    })),
+    mistakePatterns: acceptedMistakes.map((mistake) => ({
+      topic: mistake.topic,
+      description: mistake.description,
+      fixSuggestions: mistake.fixSuggestions,
+      recurrenceCount: mistake.recurrenceCount
+    })),
+    focusCard: activeFocusCard
+      ? {
+          title: activeFocusCard.title,
+          goal: activeFocusCard.goal,
+          timeframe: activeFocusCard.timeframe,
+          priority: activeFocusCard.priority,
+          successCriteria: activeFocusCard.successCriteria
+        }
+      : null,
     privacyFloor: payload.privacyFloor
   });
 
@@ -136,6 +212,7 @@ export async function createPassportSnapshot(context: AppContext, input: Record<
   const machineManifest = buildMachineManifest({
     passportId,
     title: payload.title,
+    workspaceId: workspace.id,
     privacyFloor: payload.privacyFloor,
     nodes: nodes.map((node) => ({
       id: node.id,
@@ -153,12 +230,39 @@ export async function createPassportSnapshot(context: AppContext, input: Record<
       privacyLevel: card.privacyLevel,
       relatedNodeIds: parseJsonArray<string>(card.relatedNodeIdsJson)
     })),
+    capabilitySignals: acceptedSignals.map((signal) => ({
+      id: signal.id,
+      topic: signal.topic,
+      observedPractice: signal.observedPractice,
+      currentGaps: signal.currentGaps,
+      confidence: signal.confidence
+    })),
+    mistakePatterns: acceptedMistakes.map((mistake) => ({
+      id: mistake.id,
+      topic: mistake.topic,
+      description: mistake.description,
+      fixSuggestions: mistake.fixSuggestions,
+      recurrenceCount: mistake.recurrenceCount,
+      privacyLevel: mistake.privacyLevel
+    })),
+    focusCard: activeFocusCard
+      ? {
+          id: activeFocusCard.id,
+          title: activeFocusCard.title,
+          goal: activeFocusCard.goal,
+          timeframe: activeFocusCard.timeframe,
+          priority: activeFocusCard.priority,
+          successCriteria: activeFocusCard.successCriteria,
+          relatedTopics: activeFocusCard.relatedTopics
+        }
+      : null,
     aiSummary: generated.machineManifest
   });
 
   await context.db.insert(passportSnapshots).values({
     id: passportId,
     title: payload.title,
+    workspaceId: workspace.id,
     humanMarkdown: generated.humanMarkdown,
     machineManifestJson: JSON.stringify(machineManifest),
     includeNodeIdsJson: JSON.stringify(nodes.map((node) => node.id)),

--- a/apps/web/src/server/services/postcards.ts
+++ b/apps/web/src/server/services/postcards.ts
@@ -22,10 +22,12 @@ export async function createPostcard(context: AppContext, input: PostcardCreateI
   }
 
   const postcardId = createId("card");
+  const workspaceId = input.workspaceId ?? nodes[0]?.workspaceId ?? "ws_personal";
   await context.db.insert(postcards).values({
     id: postcardId,
     cardType: input.cardType,
     title: input.title,
+    workspaceId,
     claim: input.claim,
     evidenceSummary: input.evidenceSummary,
     userView: input.userView,

--- a/apps/web/src/server/services/research.ts
+++ b/apps/web/src/server/services/research.ts
@@ -4,7 +4,10 @@ import type { ResearchQuery } from "@ai-knowledge-passport/shared";
 
 import { writeAuditLog } from "./audit";
 import { createId, nowIso } from "./common";
+import { getActiveFocusCard } from "./focus-cards";
 import { searchKnowledge } from "./search";
+import { listCapabilitySignals, listMistakePatterns } from "./signals";
+import { defaultWorkspaceId } from "./workspaces";
 
 type ResearchWarning = {
   code: "insufficient_evidence" | "conflicting_evidence" | "narrow_coverage";
@@ -45,8 +48,16 @@ export async function answerResearchQuery(context: AppContext, query: ResearchQu
   const searchResult = await searchKnowledge(context, {
     q: query.question,
     limit: query.limit,
-    projectKey: query.projectKey
+    projectKey: query.projectKey,
+    workspaceId: query.workspaceId
   });
+
+  const workspaceId = query.workspaceId ?? defaultWorkspaceId;
+  const [activeFocusCard, acceptedSignals, acceptedMistakes] = await Promise.all([
+    getActiveFocusCard(context, workspaceId),
+    listCapabilitySignals(context, { workspaceId, status: "accepted", limit: 4 }),
+    listMistakePatterns(context, { workspaceId, status: "accepted", limit: 4 })
+  ]);
 
   const fragmentEvidence = searchResult.fragments.map((fragment) => ({
     refId: fragment.id,
@@ -126,7 +137,18 @@ export async function answerResearchQuery(context: AppContext, query: ResearchQu
         }))
       }
     : await context.provider.generateAnswer({
-        question: query.question,
+        question: [
+          activeFocusCard
+            ? `Active focus:\n- ${activeFocusCard.title}\n- Goal: ${activeFocusCard.goal}\n- Timeframe: ${activeFocusCard.timeframe}\n- Priority: ${activeFocusCard.priority}`
+            : "",
+          acceptedSignals.length
+            ? `Capability signals:\n${acceptedSignals.map((signal) => `- ${signal.topic}: ${signal.observedPractice} | Gaps: ${signal.currentGaps}`).join("\n")}`
+            : "",
+          acceptedMistakes.length
+            ? `Mistake patterns:\n${acceptedMistakes.map((mistake) => `- ${mistake.topic}: ${mistake.description}`).join("\n")}`
+            : "",
+          `User question:\n${query.question}`
+        ].filter(Boolean).join("\n\n"),
         evidence
       });
 

--- a/apps/web/src/server/services/search.ts
+++ b/apps/web/src/server/services/search.ts
@@ -67,6 +67,7 @@ export async function searchKnowledge(
     q: string;
     limit?: number;
     projectKey?: string;
+    workspaceId?: string;
   }
 ): Promise<SearchKnowledgeResult> {
   const limit = query.limit ?? 8;
@@ -146,6 +147,10 @@ export async function searchKnowledge(
         return null;
       }
 
+      if (query.workspaceId && source.workspaceId !== query.workspaceId) {
+        return null;
+      }
+
       const semantic = context.provider.isConfigured
         ? cosineSimilarity(parseJsonArray<number>(fragment.embeddingJson), queryEmbedding)
         : 0;
@@ -169,6 +174,7 @@ export async function searchKnowledge(
   const nodeHits: NodeSearchHit[] = nodeDetails
     .filter((node) => node.status === "accepted")
     .filter((node) => !query.projectKey || node.projectKey === query.projectKey)
+    .filter((node) => !query.workspaceId || node.workspaceId === query.workspaceId)
     .map((node) => {
       const semantic = context.provider.isConfigured
         ? cosineSimilarity(parseJsonArray<number>(node.embeddingJson), queryEmbedding)

--- a/apps/web/src/server/services/signals.ts
+++ b/apps/web/src/server/services/signals.ts
@@ -1,0 +1,406 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import type {
+  CapabilitySignal,
+  CapabilitySignalCreateInput,
+  MistakePattern,
+  MistakePatternCreateInput,
+  PrivacyLevel
+} from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import {
+  capabilitySignals,
+  claims,
+  mistakePatterns,
+  wikiNodes
+} from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso, parseJsonArray } from "./common";
+import { getActiveFocusCard } from "./focus-cards";
+import { getWorkspace } from "./workspaces";
+
+function parseCapabilitySignal(row: typeof capabilitySignals.$inferSelect): CapabilitySignal {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    topic: row.topic,
+    observedPractice: row.observedPractice,
+    currentGaps: row.currentGaps,
+    confidence: row.confidence,
+    evidenceNodeIds: parseJsonArray<string>(row.evidenceNodeIdsJson),
+    evidenceFragmentIds: parseJsonArray<string>(row.evidenceFragmentIdsJson),
+    status: row.status as CapabilitySignal["status"],
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function parseMistakePattern(row: typeof mistakePatterns.$inferSelect): MistakePattern {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    topic: row.topic,
+    description: row.description,
+    fixSuggestions: row.fixSuggestions,
+    recurrenceCount: row.recurrenceCount,
+    exampleNodeIds: parseJsonArray<string>(row.exampleNodeIdsJson),
+    exampleFragmentIds: parseJsonArray<string>(row.exampleFragmentIdsJson),
+    privacyLevel: row.privacyLevel as PrivacyLevel,
+    status: row.status as MistakePattern["status"],
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+export async function listCapabilitySignals(
+  context: AppContext,
+  input?: {
+    workspaceId?: string;
+    status?: CapabilitySignal["status"];
+    limit?: number;
+  }
+) {
+  const workspace = await getWorkspace(context, input?.workspaceId);
+  const rows = await context.db.query.capabilitySignals.findMany({
+    where: input?.status
+      ? and(eq(capabilitySignals.workspaceId, workspace.id), eq(capabilitySignals.status, input.status))
+      : eq(capabilitySignals.workspaceId, workspace.id),
+    orderBy: [desc(capabilitySignals.updatedAt)],
+    limit: input?.limit
+  });
+  return rows.map(parseCapabilitySignal);
+}
+
+export async function listMistakePatterns(
+  context: AppContext,
+  input?: {
+    workspaceId?: string;
+    status?: MistakePattern["status"];
+    limit?: number;
+  }
+) {
+  const workspace = await getWorkspace(context, input?.workspaceId);
+  const rows = await context.db.query.mistakePatterns.findMany({
+    where: input?.status
+      ? and(eq(mistakePatterns.workspaceId, workspace.id), eq(mistakePatterns.status, input.status))
+      : eq(mistakePatterns.workspaceId, workspace.id),
+    orderBy: [desc(mistakePatterns.updatedAt)],
+    limit: input?.limit
+  });
+  return rows.map(parseMistakePattern);
+}
+
+export async function createCapabilitySignal(context: AppContext, input: CapabilitySignalCreateInput) {
+  const workspace = await getWorkspace(context, input.workspaceId);
+  const signalId = createId("signal");
+  const timestamp = nowIso();
+
+  await context.db.insert(capabilitySignals).values({
+    id: signalId,
+    workspaceId: workspace.id,
+    topic: input.topic,
+    observedPractice: input.observedPractice,
+    currentGaps: input.currentGaps,
+    confidence: input.confidence,
+    evidenceNodeIdsJson: JSON.stringify(input.evidenceNodeIds),
+    evidenceFragmentIdsJson: JSON.stringify(input.evidenceFragmentIds),
+    status: input.status,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_capability_signal",
+    objectType: "capability_signal",
+    objectId: signalId,
+    result: "succeeded",
+    notes: input.topic
+  });
+
+  return {
+    signalId,
+    auditId
+  };
+}
+
+export async function createMistakePattern(context: AppContext, input: MistakePatternCreateInput) {
+  const workspace = await getWorkspace(context, input.workspaceId);
+  const mistakeId = createId("mistake");
+  const timestamp = nowIso();
+
+  await context.db.insert(mistakePatterns).values({
+    id: mistakeId,
+    workspaceId: workspace.id,
+    topic: input.topic,
+    description: input.description,
+    fixSuggestions: input.fixSuggestions,
+    recurrenceCount: input.recurrenceCount,
+    exampleNodeIdsJson: JSON.stringify(input.exampleNodeIds),
+    exampleFragmentIdsJson: JSON.stringify(input.exampleFragmentIds),
+    privacyLevel: input.privacyLevel,
+    status: input.status,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_mistake_pattern",
+    objectType: "mistake_pattern",
+    objectId: mistakeId,
+    result: "succeeded",
+    notes: input.topic
+  });
+
+  return {
+    mistakeId,
+    auditId
+  };
+}
+
+export async function reviewCapabilitySignal(
+  context: AppContext,
+  signalId: string,
+  status: CapabilitySignal["status"]
+) {
+  const row = await context.db.query.capabilitySignals.findFirst({
+    where: eq(capabilitySignals.id, signalId)
+  });
+
+  if (!row) {
+    throw new Error("Capability signal not found.");
+  }
+
+  await context.db
+    .update(capabilitySignals)
+    .set({
+      status,
+      updatedAt: nowIso()
+    })
+    .where(eq(capabilitySignals.id, signalId));
+
+  await writeAuditLog(context, {
+    actionType: `review_capability_signal_${status}`,
+    objectType: "capability_signal",
+    objectId: signalId,
+    result: "succeeded",
+    notes: row.topic
+  });
+}
+
+export async function reviewMistakePattern(
+  context: AppContext,
+  mistakeId: string,
+  status: MistakePattern["status"]
+) {
+  const row = await context.db.query.mistakePatterns.findFirst({
+    where: eq(mistakePatterns.id, mistakeId)
+  });
+
+  if (!row) {
+    throw new Error("Mistake pattern not found.");
+  }
+
+  await context.db
+    .update(mistakePatterns)
+    .set({
+      status,
+      updatedAt: nowIso()
+    })
+    .where(eq(mistakePatterns.id, mistakeId));
+
+  await writeAuditLog(context, {
+    actionType: `review_mistake_pattern_${status}`,
+    objectType: "mistake_pattern",
+    objectId: mistakeId,
+    result: "succeeded",
+    notes: row.topic
+  });
+}
+
+export async function generateLearnerStateForWorkspace(context: AppContext, workspaceId: string) {
+  if (!context.provider.isConfigured) {
+    return {
+      signalsCreated: 0,
+      mistakesCreated: 0
+    };
+  }
+
+  const workspace = await getWorkspace(context, workspaceId);
+  const [acceptedNodes, workspaceClaims] = await Promise.all([
+    context.db.query.wikiNodes.findMany({
+      where: and(eq(wikiNodes.workspaceId, workspace.id), eq(wikiNodes.status, "accepted")),
+      orderBy: [desc(wikiNodes.updatedAt)],
+      limit: 20
+    }),
+    context.db.query.claims.findMany({
+      where: eq(claims.workspaceId, workspace.id),
+      orderBy: [desc(claims.updatedAt)],
+      limit: 30
+    })
+  ]);
+
+  if (!acceptedNodes.length && !workspaceClaims.length) {
+    return {
+      signalsCreated: 0,
+      mistakesCreated: 0
+    };
+  }
+
+  const generated = await context.provider.generateLearnerState({
+    workspaceTitle: workspace.title,
+    nodes: acceptedNodes.map((node) => ({
+      id: node.id,
+      title: node.title,
+      summary: node.summary,
+      bodyMd: node.bodyMd,
+      tags: parseJsonArray<string>(node.tagsJson),
+      projectKey: node.projectKey
+    })),
+    claims: workspaceClaims.map((claim) => ({
+      id: claim.id,
+      title: claim.title,
+      statement: claim.statement,
+      confidence: claim.confidence,
+      tags: parseJsonArray<string>(claim.tagsJson),
+      sourceFragmentIds: parseJsonArray<string>(claim.sourceFragmentIdsJson),
+      nodeId: claim.nodeId ?? null
+    }))
+  });
+
+  let signalsCreated = 0;
+  for (const candidate of generated.capabilitySignals) {
+    const existing = await context.db.query.capabilitySignals.findFirst({
+      where: and(
+        eq(capabilitySignals.workspaceId, workspace.id),
+        eq(capabilitySignals.topic, candidate.topic),
+        eq(capabilitySignals.status, "pending_review")
+      )
+    });
+
+    const timestamp = nowIso();
+    if (existing) {
+      await context.db
+        .update(capabilitySignals)
+        .set({
+          observedPractice: candidate.observedPractice,
+          currentGaps: candidate.currentGaps,
+          confidence: candidate.confidence,
+          evidenceNodeIdsJson: JSON.stringify(candidate.evidenceNodeIds),
+          evidenceFragmentIdsJson: JSON.stringify(candidate.evidenceFragmentIds),
+          updatedAt: timestamp
+        })
+        .where(eq(capabilitySignals.id, existing.id));
+    } else {
+      await context.db.insert(capabilitySignals).values({
+        id: createId("signal"),
+        workspaceId: workspace.id,
+        topic: candidate.topic,
+        observedPractice: candidate.observedPractice,
+        currentGaps: candidate.currentGaps,
+        confidence: candidate.confidence,
+        evidenceNodeIdsJson: JSON.stringify(candidate.evidenceNodeIds),
+        evidenceFragmentIdsJson: JSON.stringify(candidate.evidenceFragmentIds),
+        status: "pending_review",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      });
+    }
+    signalsCreated += 1;
+  }
+
+  let mistakesCreated = 0;
+  for (const candidate of generated.mistakePatterns) {
+    const existing = await context.db.query.mistakePatterns.findFirst({
+      where: and(
+        eq(mistakePatterns.workspaceId, workspace.id),
+        eq(mistakePatterns.topic, candidate.topic),
+        eq(mistakePatterns.status, "pending_review")
+      )
+    });
+
+    const timestamp = nowIso();
+    if (existing) {
+      await context.db
+        .update(mistakePatterns)
+        .set({
+          description: candidate.description,
+          fixSuggestions: candidate.fixSuggestions,
+          recurrenceCount: candidate.recurrenceCount,
+          exampleNodeIdsJson: JSON.stringify(candidate.exampleNodeIds),
+          exampleFragmentIdsJson: JSON.stringify(candidate.exampleFragmentIds),
+          privacyLevel: candidate.privacyLevel,
+          updatedAt: timestamp
+        })
+        .where(eq(mistakePatterns.id, existing.id));
+    } else {
+      await context.db.insert(mistakePatterns).values({
+        id: createId("mistake"),
+        workspaceId: workspace.id,
+        topic: candidate.topic,
+        description: candidate.description,
+        fixSuggestions: candidate.fixSuggestions,
+        recurrenceCount: candidate.recurrenceCount,
+        exampleNodeIdsJson: JSON.stringify(candidate.exampleNodeIds),
+        exampleFragmentIdsJson: JSON.stringify(candidate.exampleFragmentIds),
+        privacyLevel: candidate.privacyLevel,
+        status: "pending_review",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      });
+    }
+    mistakesCreated += 1;
+  }
+
+  await writeAuditLog(context, {
+    actionType: "generate_learner_state",
+    objectType: "workspace",
+    objectId: workspace.id,
+    result: "succeeded",
+    notes: `signals:${signalsCreated} mistakes:${mistakesCreated}`
+  });
+
+  return {
+    signalsCreated,
+    mistakesCreated
+  };
+}
+
+export async function buildWorkspaceContextBlock(context: AppContext, workspaceId?: string | null) {
+  if (!workspaceId) {
+    return "";
+  }
+
+  const [focusCard, acceptedSignals, acceptedMistakes] = await Promise.all([
+    getActiveFocusCard(context, workspaceId),
+    listCapabilitySignals(context, { workspaceId, status: "accepted", limit: 4 }),
+    listMistakePatterns(context, { workspaceId, status: "accepted", limit: 4 })
+  ]);
+
+  const lines: string[] = [];
+  if (focusCard) {
+    lines.push(
+      `Active focus: ${focusCard.title}`,
+      `Goal: ${focusCard.goal}`,
+      `Timeframe: ${focusCard.timeframe || "unspecified"}`,
+      `Priority: ${focusCard.priority}`
+    );
+  }
+
+  if (acceptedSignals.length) {
+    lines.push(
+      "Capability signals:",
+      ...acceptedSignals.map((signal) => `- ${signal.topic}: ${signal.observedPractice} | Gaps: ${signal.currentGaps}`)
+    );
+  }
+
+  if (acceptedMistakes.length) {
+    lines.push(
+      "Mistake patterns:",
+      ...acceptedMistakes.map((mistake) => `- ${mistake.topic}: ${mistake.description}`)
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/apps/web/src/server/services/sources.ts
+++ b/apps/web/src/server/services/sources.ts
@@ -12,6 +12,7 @@ import { syncSourceFragmentFts } from "./fts";
 import { enqueueJob, maybeRunInlineJobs } from "./jobs";
 import { normalizeSourceContent } from "./parsers";
 import { storeBufferAsset, storeTextAsset } from "./storage";
+import { getWorkspace } from "./workspaces";
 
 type ImportSourceOptions = {
   payload: ImportPayload;
@@ -19,6 +20,7 @@ type ImportSourceOptions = {
 };
 
 export async function createSourceImport(context: AppContext, options: ImportSourceOptions) {
+  const workspace = await getWorkspace(context, options.payload.workspaceId);
   const sourceId = createId("src");
   const importedAt = nowIso();
   let filePath: string | undefined;
@@ -79,6 +81,7 @@ export async function createSourceImport(context: AppContext, options: ImportSou
     type: options.payload.type,
     title: options.payload.title,
     originUrl: options.payload.originUrl ?? null,
+    workspaceId: workspace.id,
     createdAt: options.payload.createdAt ?? null,
     importedAt,
     filePath: filePath ?? null,

--- a/apps/web/src/server/services/workspaces.ts
+++ b/apps/web/src/server/services/workspaces.ts
@@ -1,0 +1,97 @@
+import { asc, eq } from "drizzle-orm";
+
+import type { WorkspaceCreateInput, WorkspaceRecord } from "@ai-knowledge-passport/shared";
+
+import type { AppContext } from "@/server/context";
+import { workspaces } from "@/server/db/schema";
+
+import { writeAuditLog } from "./audit";
+import { createId, nowIso } from "./common";
+
+export const defaultWorkspaceId = "ws_personal";
+
+function parseWorkspace(row: typeof workspaces.$inferSelect): WorkspaceRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    workspaceType: row.workspaceType as WorkspaceRecord["workspaceType"],
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+export async function ensureDefaultWorkspace(context: AppContext) {
+  const existing = await context.db.query.workspaces.findFirst({
+    where: eq(workspaces.id, defaultWorkspaceId)
+  });
+
+  if (existing) {
+    return parseWorkspace(existing);
+  }
+
+  const timestamp = nowIso();
+  await context.db.insert(workspaces).values({
+    id: defaultWorkspaceId,
+    title: "Personal",
+    workspaceType: "personal",
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  return {
+    id: defaultWorkspaceId,
+    title: "Personal",
+    workspaceType: "personal" as const,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+}
+
+export async function listWorkspaces(context: AppContext) {
+  await ensureDefaultWorkspace(context);
+  const rows = await context.db.query.workspaces.findMany({
+    orderBy: [asc(workspaces.createdAt)]
+  });
+  return rows.map(parseWorkspace);
+}
+
+export async function createWorkspace(context: AppContext, input: WorkspaceCreateInput) {
+  const workspaceId = createId("ws");
+  const timestamp = nowIso();
+  await context.db.insert(workspaces).values({
+    id: workspaceId,
+    title: input.title,
+    workspaceType: input.workspaceType,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  const auditId = await writeAuditLog(context, {
+    actionType: "create_workspace",
+    objectType: "workspace",
+    objectId: workspaceId,
+    result: "succeeded",
+    notes: input.title
+  });
+
+  return {
+    workspaceId,
+    auditId
+  };
+}
+
+export async function getWorkspace(context: AppContext, workspaceId?: string | null) {
+  if (!workspaceId) {
+    return ensureDefaultWorkspace(context);
+  }
+
+  const row = await context.db.query.workspaces.findFirst({
+    where: eq(workspaces.id, workspaceId)
+  });
+
+  if (!row) {
+    throw new Error("Workspace not found.");
+  }
+
+  return parseWorkspace(row);
+}

--- a/apps/web/src/server/tests/audit.test.ts
+++ b/apps/web/src/server/tests/audit.test.ts
@@ -17,6 +17,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 

--- a/apps/web/src/server/tests/avatar-live-sessions.test.ts
+++ b/apps/web/src/server/tests/avatar-live-sessions.test.ts
@@ -30,6 +30,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
     return {
       answerMd: `Live governed answer: ${input.evidence[0]?.text ?? ""}`,
@@ -69,6 +70,7 @@ async function seedAvatarFixture(context: ReturnType<typeof createAppContext>) {
       id: nodeId,
       nodeType: "summary",
       title: "Knowledge Passport",
+      workspaceId: "ws_personal",
       summary: "A knowledge passport compiles private material into reusable governed context.",
       bodyMd: "Knowledge passports provide governed context and evidence-backed expression.",
       status: "accepted",
@@ -84,6 +86,7 @@ async function seedAvatarFixture(context: ReturnType<typeof createAppContext>) {
       id: nodeTwoId,
       nodeType: "summary",
       title: "Pricing Strategy",
+      workspaceId: "ws_personal",
       summary: "Private pricing should not be delegated.",
       bodyMd: "Pricing is a forbidden topic for governed agents.",
       status: "accepted",
@@ -101,6 +104,7 @@ async function seedAvatarFixture(context: ReturnType<typeof createAppContext>) {
     id: cardId,
     cardType: "knowledge",
     title: "Passport Card",
+    workspaceId: "ws_personal",
     claim: "Knowledge passports package evidence-based context.",
     evidenceSummary: "Grounded in accepted node summaries.",
     userView: "Use it for controlled sharing.",

--- a/apps/web/src/server/tests/avatars.test.ts
+++ b/apps/web/src/server/tests/avatars.test.ts
@@ -27,6 +27,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
     return {
       answerMd: `Governed answer: ${input.evidence[0]?.text ?? ""}`,
@@ -66,6 +67,7 @@ async function seedPackFixtures(context: ReturnType<typeof createAppContext>) {
       id: nodeId,
       nodeType: "summary",
       title: "Knowledge Passport",
+      workspaceId: "ws_personal",
       summary: "A knowledge passport compiles private material into reusable, governed context.",
       bodyMd: "The knowledge passport is for governed context and evidence-backed expression.",
       status: "accepted",
@@ -81,6 +83,7 @@ async function seedPackFixtures(context: ReturnType<typeof createAppContext>) {
       id: nodeTwoId,
       nodeType: "summary",
       title: "Pricing Strategy",
+      workspaceId: "ws_personal",
       summary: "Private pricing decisions should not be delegated.",
       bodyMd: "Pricing should remain a forbidden topic for delegated agents.",
       status: "accepted",
@@ -98,6 +101,7 @@ async function seedPackFixtures(context: ReturnType<typeof createAppContext>) {
     id: cardId,
     cardType: "knowledge",
     title: "Passport Card",
+    workspaceId: "ws_personal",
     claim: "Knowledge passports package evidence-based context.",
     evidenceSummary: "Grounded in accepted node summaries.",
     userView: "Use it for controlled sharing.",

--- a/apps/web/src/server/tests/claims.test.ts
+++ b/apps/web/src/server/tests/claims.test.ts
@@ -32,6 +32,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 

--- a/apps/web/src/server/tests/compilation-runs.test.ts
+++ b/apps/web/src/server/tests/compilation-runs.test.ts
@@ -32,6 +32,7 @@ class FakeProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 

--- a/apps/web/src/server/tests/context-layer.test.ts
+++ b/apps/web/src/server/tests/context-layer.test.ts
@@ -1,0 +1,172 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { applyReviewAction, compileSource } from "@/server/services/compiler";
+import { createFocusCard } from "@/server/services/focus-cards";
+import { createPassportSnapshot, getPassportSnapshot } from "@/server/services/passports";
+import { reviewCapabilitySignal, reviewMistakePattern, listCapabilitySignals, listMistakePatterns } from "@/server/services/signals";
+import { createSourceImport } from "@/server/services/sources";
+import { listWorkspaces } from "@/server/services/workspaces";
+
+import { describe, expect, it } from "vitest";
+
+class ContextProvider implements ModelProvider {
+  readonly isConfigured = true;
+
+  async extractStructured() {
+    return {
+      summary: "summary",
+      keyClaims: ["claim"],
+      concepts: ["concept"],
+      themes: ["theme"],
+      tags: ["mountable"]
+    };
+  }
+
+  async summarizeAndLink(input: Parameters<ModelProvider["summarizeAndLink"]>[0]) {
+    return {
+      nodes: [
+        {
+          nodeType: "summary" as const,
+          title: `${input.title} summary`,
+          summary: input.text.slice(0, 80),
+          bodyMd: input.text,
+          tags: ["context", "passport"]
+        }
+      ],
+      relationHints: []
+    };
+  }
+
+  async embedText(input: string[]) {
+    return input.map((entry) => Array.from(entry).slice(0, 6).map((char) => char.charCodeAt(0) / 255));
+  }
+
+  async transcribeAudio() {
+    return "audio";
+  }
+
+  async generateAnswer() {
+    return { answerMd: "answer", citations: [] };
+  }
+
+  async generateCard() {
+    return { claim: "claim", evidenceSummary: "evidence", userView: "view" };
+  }
+
+  async generatePassport(input: Parameters<ModelProvider["generatePassport"]>[0]) {
+    return {
+      humanMarkdown: `# ${input.title}\n\n${input.focusCard ? `Focus: ${input.focusCard.title}` : "No focus"}`,
+      machineManifest: {
+        title: input.title,
+        focusCard: input.focusCard,
+        capabilitySignals: input.capabilitySignals,
+        mistakePatterns: input.mistakePatterns
+      }
+    };
+  }
+
+  async generateLearnerState(input: Parameters<ModelProvider["generateLearnerState"]>[0]) {
+    return {
+      capabilitySignals: [
+        {
+          topic: "Knowledge framing",
+          observedPractice: "Can summarize a governed knowledge base.",
+          currentGaps: "Needs a clearer outward-first framing.",
+          confidence: 0.72,
+          evidenceNodeIds: input.nodes.slice(0, 1).map((node) => node.id),
+          evidenceFragmentIds: input.claims.slice(0, 1).flatMap((claim) => claim.sourceFragmentIds)
+        }
+      ],
+      mistakePatterns: [
+        {
+          topic: "Over-scoping",
+          description: "Tends to describe the system too broadly before the first user value is sharp.",
+          fixSuggestions: "Anchor the product around one AI-readable entry object first.",
+          recurrenceCount: 2,
+          exampleNodeIds: input.nodes.slice(0, 1).map((node) => node.id),
+          exampleFragmentIds: input.claims.slice(0, 1).flatMap((claim) => claim.sourceFragmentIds),
+          privacyLevel: "L1_LOCAL_AI" as const
+        }
+      ]
+    };
+  }
+
+  async generateAvatarReply() {
+    return { answerMd: "avatar", citations: [] };
+  }
+}
+
+describe("product refocus context layer", () => {
+  it("bootstraps a default workspace, generates learner-state candidates, and enriches passport context", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "akp-context-"));
+    const dataDir = path.join(tempRoot, "data");
+    await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+    const context = createAppContext({
+      dataDir,
+      databasePath: path.join(dataDir, "test.sqlite"),
+      provider: new ContextProvider()
+    });
+
+    const workspaces = await listWorkspaces(context);
+    expect(workspaces[0]?.id).toBe("ws_personal");
+
+    const importResult = await createSourceImport(context, {
+      payload: {
+        type: "markdown",
+        title: "Product framing notes",
+        workspaceId: "ws_personal",
+        privacyLevel: "L1_LOCAL_AI",
+        textContent: "The first value is helping AI understand the user quickly under authorization.",
+        tags: ["focus", "passport"],
+        metadata: {}
+      }
+    });
+
+    const nodes = await compileSource(context, importResult.sourceId);
+    expect(nodes.length).toBe(1);
+    await applyReviewAction(context, {
+      nodeId: nodes[0]?.id ?? "",
+      action: "accept"
+    });
+
+    const pendingSignals = await listCapabilitySignals(context, { workspaceId: "ws_personal", status: "pending_review" });
+    const pendingMistakes = await listMistakePatterns(context, { workspaceId: "ws_personal", status: "pending_review" });
+    expect(pendingSignals).toHaveLength(1);
+    expect(pendingMistakes).toHaveLength(1);
+
+    await reviewCapabilitySignal(context, pendingSignals[0]!.id, "accepted");
+    await reviewMistakePattern(context, pendingMistakes[0]!.id, "accepted");
+
+    await createFocusCard(context, {
+      workspaceId: "ws_personal",
+      title: "Sharpen the first user value",
+      goal: "Make the passport the default AI entry object.",
+      timeframe: "This week",
+      priority: "high",
+      successCriteria: "A mounted AI can understand the user without repeated explanation.",
+      relatedTopics: ["passport", "signals"],
+      status: "active"
+    });
+
+    const passportId = await createPassportSnapshot(context, {
+      title: "Focused Passport",
+      workspaceId: "ws_personal",
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+
+    const passport = await getPassportSnapshot(context, passportId);
+    expect(passport?.workspaceId).toBe("ws_personal");
+    expect((passport?.machineManifest as { focusCard?: { title?: string } }).focusCard?.title).toBe("Sharpen the first user value");
+    expect(((passport?.machineManifest as { capabilitySignals?: unknown[] }).capabilitySignals ?? []).length).toBe(1);
+    expect(((passport?.machineManifest as { mistakePatterns?: unknown[] }).mistakePatterns ?? []).length).toBe(1);
+  });
+});

--- a/apps/web/src/server/tests/exports.test.ts
+++ b/apps/web/src/server/tests/exports.test.ts
@@ -28,6 +28,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
@@ -54,6 +55,7 @@ async function seedExportFixtures(context: ReturnType<typeof createAppContext>) 
     id: nodeId,
     nodeType: "summary",
     title: "Agent Pack Node",
+    workspaceId: "ws_personal",
     summary: "Node summary",
     bodyMd: "Node body markdown",
     status: "accepted",
@@ -70,6 +72,7 @@ async function seedExportFixtures(context: ReturnType<typeof createAppContext>) 
     id: cardId,
     cardType: "knowledge",
     title: "Agent Pack Card",
+    workspaceId: "ws_personal",
     claim: "Cards capture shareable knowledge claims.",
     evidenceSummary: "Backed by accepted nodes.",
     userView: "A compact governed expression layer.",
@@ -195,6 +198,7 @@ describe("export packages", () => {
         id: extraNodeId,
         nodeType: "summary",
         title: "Second Node",
+        workspaceId: "ws_personal",
         summary: "Second summary",
         bodyMd: "Second body",
         status: "accepted",

--- a/apps/web/src/server/tests/fragments.test.ts
+++ b/apps/web/src/server/tests/fragments.test.ts
@@ -18,6 +18,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
@@ -39,6 +40,7 @@ describe("fragment service", () => {
       id: "src_1",
       type: "markdown",
       title: "Fragment Source",
+      workspaceId: "ws_personal",
       importedAt: new Date().toISOString(),
       filePath: null,
       privacyLevel: "L1_LOCAL_AI",

--- a/apps/web/src/server/tests/grants.test.ts
+++ b/apps/web/src/server/tests/grants.test.ts
@@ -17,6 +17,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 

--- a/apps/web/src/server/tests/health.test.ts
+++ b/apps/web/src/server/tests/health.test.ts
@@ -19,6 +19,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
@@ -40,6 +41,7 @@ describe("health report", () => {
       id: "src_failed",
       type: "markdown",
       title: "Broken Source",
+      workspaceId: "ws_personal",
       importedAt: new Date().toISOString(),
       filePath: null,
       privacyLevel: "L1_LOCAL_AI",
@@ -57,6 +59,7 @@ describe("health report", () => {
         id: "node_a",
         nodeType: "summary",
         title: "Duplicate Topic",
+        workspaceId: "ws_personal",
         summary: "A",
         bodyMd: "A",
         status: "accepted",
@@ -72,6 +75,7 @@ describe("health report", () => {
         id: "node_b",
         nodeType: "summary",
         title: "Duplicate Topic",
+        workspaceId: "ws_personal",
         summary: "B",
         bodyMd: "B",
         status: "pending_review",

--- a/apps/web/src/server/tests/mvp.test.ts
+++ b/apps/web/src/server/tests/mvp.test.ts
@@ -91,6 +91,13 @@ class FakeProvider implements ModelProvider {
     };
   }
 
+  async generateLearnerState() {
+    return {
+      capabilitySignals: [],
+      mistakePatterns: []
+    };
+  }
+
   async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
     return {
       answerMd: `Avatar reply grounded in pack evidence: ${input.evidence[0]?.text ?? ""}`,
@@ -211,6 +218,7 @@ describe("knowledge passport MVP flow", () => {
       id: existingNodeId,
       nodeType: "summary",
       title: "AI Passport Notes / Summary",
+      workspaceId: "ws_personal",
       summary: "Existing knowledge node",
       bodyMd: "# AI Passport Notes\n\nExisting knowledge body",
       status: "accepted",
@@ -309,6 +317,7 @@ describe("knowledge passport MVP flow", () => {
         id: targetNodeId,
         nodeType: "theme",
         title: "Knowledge Passport",
+        workspaceId: "ws_personal",
         summary: "Primary node",
         bodyMd: "Primary body",
         status: "accepted",
@@ -324,6 +333,7 @@ describe("knowledge passport MVP flow", () => {
         id: pendingNodeId,
         nodeType: "theme",
         title: "Knowledge Passport Candidate",
+        workspaceId: "ws_personal",
         summary: "Pending node",
         bodyMd: "Pending node body",
         status: "pending_review",
@@ -339,6 +349,7 @@ describe("knowledge passport MVP flow", () => {
         id: relatedNodeId,
         nodeType: "concept",
         title: "Evidence Chain",
+        workspaceId: "ws_personal",
         summary: "Related node",
         bodyMd: "Related node body",
         status: "accepted",

--- a/apps/web/src/server/tests/policies.test.ts
+++ b/apps/web/src/server/tests/policies.test.ts
@@ -30,6 +30,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "avatar answer", citations: [] }; }
 }
 
@@ -57,6 +58,7 @@ async function seedGovernedObjects(context: ReturnType<typeof createAppContext>)
     id: nodeId,
     nodeType: "summary",
     title: "Governed Node",
+    workspaceId: "ws_personal",
     summary: "Node summary",
     bodyMd: "Node body for governed policy tests",
     status: "accepted",
@@ -73,6 +75,7 @@ async function seedGovernedObjects(context: ReturnType<typeof createAppContext>)
     id: cardId,
     cardType: "knowledge",
     title: "Governed Card",
+    workspaceId: "ws_personal",
     claim: "Governed claim",
     evidenceSummary: "Governed evidence",
     userView: "Governed view",
@@ -87,6 +90,7 @@ async function seedGovernedObjects(context: ReturnType<typeof createAppContext>)
   await context.db.insert(passportSnapshots).values({
     id: passportId,
     title: "Governed Passport",
+    workspaceId: "ws_personal",
     humanMarkdown: "# Governed Passport",
     machineManifestJson: JSON.stringify({ title: "Governed Passport" }),
     includeNodeIdsJson: JSON.stringify([nodeId]),
@@ -185,6 +189,7 @@ describe("object policies", () => {
       id: nodeId,
       nodeType: "summary",
       title: "Visa Policy Node",
+      workspaceId: "ws_personal",
       summary: "Node summary",
       bodyMd: "Node body",
       status: "accepted",
@@ -200,6 +205,7 @@ describe("object policies", () => {
       id: cardId,
       cardType: "knowledge",
       title: "Visa Policy Card",
+      workspaceId: "ws_personal",
       claim: "Claim",
       evidenceSummary: "Evidence",
       userView: "View",
@@ -213,6 +219,7 @@ describe("object policies", () => {
     await context.db.insert(passportSnapshots).values({
       id: passportId,
       title: "Passport",
+      workspaceId: "ws_personal",
       humanMarkdown: "# Passport",
       machineManifestJson: JSON.stringify({ title: "Passport" }),
       includeNodeIdsJson: JSON.stringify([nodeId]),

--- a/apps/web/src/server/tests/visas.test.ts
+++ b/apps/web/src/server/tests/visas.test.ts
@@ -36,6 +36,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
@@ -64,6 +65,7 @@ async function seedVisaFixtures(context: ReturnType<typeof createAppContext>) {
     id: sourceId,
     type: "markdown",
     title: "Visa Source",
+    workspaceId: "ws_personal",
     originUrl: "https://example.com/source",
     createdAt: timestamp,
     importedAt: timestamp,
@@ -82,6 +84,7 @@ async function seedVisaFixtures(context: ReturnType<typeof createAppContext>) {
     id: nodeId,
     nodeType: "summary",
     title: "Visa Node",
+    workspaceId: "ws_personal",
     summary: "Node summary",
     bodyMd: "# Visa Node\n\nNode body",
     status: "accepted",
@@ -98,6 +101,7 @@ async function seedVisaFixtures(context: ReturnType<typeof createAppContext>) {
     id: cardId,
     cardType: "knowledge",
     title: "Visa Card",
+    workspaceId: "ws_personal",
     claim: "Visa cards package context for a specific audience.",
     evidenceSummary: "Evidence stays traceable while the bundle stays scoped.",
     userView: "This is a good shareable layer.",
@@ -112,6 +116,7 @@ async function seedVisaFixtures(context: ReturnType<typeof createAppContext>) {
   await context.db.insert(passportSnapshots).values({
     id: passportId,
     title: "Visa Passport",
+    workspaceId: "ws_personal",
     humanMarkdown: "# Visa Passport",
     machineManifestJson: JSON.stringify({ title: "Visa Passport" }),
     includeNodeIdsJson: JSON.stringify([nodeId]),

--- a/apps/web/src/server/tests/visuals.test.ts
+++ b/apps/web/src/server/tests/visuals.test.ts
@@ -18,6 +18,7 @@ class StubProvider implements ModelProvider {
   async generateAnswer() { return { answerMd: "", citations: [] }; }
   async generateCard() { return { claim: "", evidenceSummary: "", userView: "" }; }
   async generatePassport() { return { humanMarkdown: "", machineManifest: {} }; }
+  async generateLearnerState() { return { capabilitySignals: [], mistakePatterns: [] }; }
   async generateAvatarReply() { return { answerMd: "", citations: [] }; }
 }
 
@@ -40,6 +41,7 @@ describe("visual overview", () => {
         id: "src_1",
         type: "markdown",
         title: "Source One",
+        workspaceId: "ws_personal",
         importedAt: new Date().toISOString(),
         filePath: null,
         privacyLevel: "L1_LOCAL_AI",
@@ -55,6 +57,7 @@ describe("visual overview", () => {
         id: "src_2",
         type: "markdown",
         title: "Source Two",
+        workspaceId: "ws_personal",
         importedAt: new Date().toISOString(),
         filePath: null,
         privacyLevel: "L3_PUBLIC",
@@ -73,6 +76,7 @@ describe("visual overview", () => {
         id: "node_1",
         nodeType: "theme",
         title: "Knowledge Mapping",
+        workspaceId: "ws_personal",
         summary: "Theme node",
         bodyMd: "Body",
         status: "accepted",
@@ -90,6 +94,7 @@ describe("visual overview", () => {
       id: "card_1",
       cardType: "knowledge",
       title: "Mapping Card",
+      workspaceId: "ws_personal",
       claim: "Claim",
       evidenceSummary: "Evidence",
       userView: "View",

--- a/docs/project-blueprint.md
+++ b/docs/project-blueprint.md
@@ -2,7 +2,7 @@
 
 ## One-line Definition
 
-AI Personal Knowledge Passport System is a local-first system for personal knowledge compilation, authorized projection, and agent governance.
+AI Personal Knowledge Passport System is an AI-mountable personal knowledge base: a local-first system for knowledge compilation, authorized projection, and governed AI use.
 
 ## Why This Exists
 
@@ -15,19 +15,19 @@ Most current knowledge workflows still break in four places:
 - private knowledge and outward expression are disconnected
 - personal expression and future digital agents are disconnected
 
-This system exists to repair those four breaks by treating personal knowledge as governed digital infrastructure instead of passive notes.
+This system exists to repair those four breaks by turning personal knowledge into a governed AI-readable context layer instead of passive notes.
 
 ## Core Product Nature
 
 This is not primarily a note-taking app and not primarily a chat UI.
 
-It is a three-part system:
+It is a layered product:
 
-1. A knowledge compiler
-2. A capability projection layer
-3. An agent governance layer
+1. A core context compiler
+2. A passport and mount layer
+3. A governed agent layer
 
-The goal is to turn private materials into traceable, reusable, authorized knowledge assets.
+The goal is to help any AI understand the user’s foundation, current goal, and blind spots quickly under authorization.
 
 ## Double-loop Model
 
@@ -35,13 +35,13 @@ The goal is to turn private materials into traceable, reusable, authorized knowl
 
 Raw material enters the system, is incrementally compiled into local knowledge structures, becomes queryable for research and outputs, then flows back into the knowledge base as new structured artifacts.
 
-`source -> compile -> wiki/claims -> research -> output -> flowback -> recompile`
+`source -> compile -> signals -> postcards -> passport -> research/output -> flowback`
 
-### Outer Loop: Social Circulation
+### Outer Loop: Mount and Governance
 
-Internal knowledge artifacts are compressed into postcards, organized into passports, cut into scenario bundles, used in collaboration or AI transfer, and then logged and reviewed for controlled re-entry.
+Internal knowledge artifacts are compressed into postcards, organized into passports, narrowed into visas, used in governed AI sessions or export bundles, and then logged and reviewed for controlled re-entry.
 
-`knowledge -> postcard/passport -> scenario bundle -> external use -> audit -> review -> update`
+`knowledge -> postcard/passport -> visa/agent pack -> governed use -> audit -> review -> update`
 
 ## System Layers
 
@@ -75,23 +75,23 @@ Controls future digital-agent access through explicit knowledge packs, boundarie
 
 ## Core Object Chain
 
-The internal object chain should continue to evolve around:
+The current object chain is best understood as:
 
-`Source -> Fragment -> Claim -> Wiki Node -> Postcard -> Passport / Visa -> Avatar Pack`
+`Source -> Fragment -> Claim -> Wiki Node -> Capability Signal / Mistake Pattern / Focus Card -> Postcard -> Passport -> Visa -> Agent Pack -> Avatar`
 
-Governance objects around that chain should include:
+Governance objects around that chain include:
 
 - Grant / Policy
 - Compilation Run
 - Audit Log
 - Output
 
-The biggest architectural upgrades still missing or partial today are:
+The current strategic reset is not about adding more layers. It is about making the first AI-readable layer sharper:
 
-- explicit Fragment-centric evidence modeling
-- explicit Claim modeling
-- explicit Grant / authorization records
-- explicit Compilation Run history
+- workspace-scoped context
+- capability signals instead of hard ability claims
+- mistake patterns instead of vague “AI memory”
+- active focus cards so AI understands the user’s present, not only their past
 
 ## Front-stage Expression Model
 
@@ -103,11 +103,11 @@ The smallest expressive unit for a theme, claim, method, or project.
 
 ### Passport
 
-A structured capability interface for people and AI systems to quickly understand a person’s themes, evidence, methods, and boundaries.
+The canonical AI entry object for quickly understanding the user’s themes, active goal, signals, blind spots, and boundaries.
 
 ### Visa / Scenario Bundle
 
-A constrained context package for a specific audience, task, and time window.
+A constrained mount-time context package for a specific audience, task, and time window.
 
 ## Core Principles
 
@@ -128,43 +128,37 @@ The first strong-fit user is not “everyone who takes notes.” It is the long-
 - uses multiple AI systems but wants one persistent private context base
 - expects future AI delegation to require clear boundaries
 
-## MVP Definition
+## Current Product Reset
 
-The MVP should prove one loop end-to-end:
+The product now treats this as the primary loop:
 
-`import -> compile -> local research -> cited output -> flowback -> postcard -> lightweight passport -> local backup`
+`import -> compile -> signals -> postcard -> passport -> mount`
 
-The MVP is successful when a user’s private materials can be transformed into reusable, cited, exportable, and authorization-aware knowledge assets.
+The product is successful when an AI can read the passport layer and give more relevant help with less repeated explanation.
 
 ## Suggested Delivery Phases
 
-### MVP
+### Foundation
 
 - multi-source import
-- incremental local wiki compilation
-- local-first Q&A with citations
-- markdown / brief outputs with flowback
-- postcards
-- lightweight passports
-- local backup
+- incremental local compilation
+- accepted nodes and claims
+- citations and flowback
+- postcards and passports
 
-### V1
+### Mount Layer
 
-- scenario bundles / visas
-- sharing controls and access logs
-- health center
-- evidence-chain views
-- machine-readable passports
-- project migration views
+- visas
+- access analytics
+- controlled feedback flowback
 
-### V2
+### Governed AI Layer
 
-- avatar console
-- agent knowledge packs
-- escalation and audit rules for agents
-- finer-grained permission engine
-- cross-AI standard knowledge package export
-- multi-device sync and collaboration governance
+- agent packs
+- avatars
+- internal live governed sessions
+- cross-AI exports
+- policy engine
 
 ## Success Metrics
 
@@ -172,12 +166,12 @@ The best north-star metric is not raw DAU or import count.
 
 It is:
 
-The number of effective knowledge units that were reused, flowed back, authorized outward, or used by a governed agent in the last 30 days.
+The number of times an AI can successfully help the user after reading passport context, without the user having to re-explain core background.
 
 Supporting metrics:
 
 - source-to-node conversion rate
-- node-to-postcard/passport conversion rate
+- node-to-signal/passport conversion rate
 - citation-backed answer rate
 - output flowback rate
 - scenario bundle usage count
@@ -187,13 +181,11 @@ Supporting metrics:
 
 ## Current Strategic Priority
 
-The repo already contains the early MVP backbone.
+The repo already contains deep advanced layers. The present priority is product sharpness:
 
-The most important next-system upgrades are:
+1. Make workspace-scoped AI context explicit
+2. Make capability signals and mistake patterns first-class
+3. Make focus cards the active-goal layer
+4. Make passport the canonical AI entry surface
 
-1. Make Fragment a first-class evidence model
-2. Make Claim a first-class knowledge object
-3. Make authorization a first-class Grant layer
-4. Make compilation history explicit with Compilation Run records
-
-If those layers mature, the system becomes more than a well-organized PKM app. It becomes a real personal knowledge sovereignty infrastructure.
+If those layers mature, the system stops reading like a broad future-total platform and starts behaving like a concrete AI-readable personal knowledge base.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,12 @@ export const privacyLevels = [
   "L4_AGENT_ONLY"
 ] as const;
 
+export const workspaceTypes = [
+  "personal",
+  "work",
+  "project"
+] as const;
+
 export const sourceTypes = [
   "markdown",
   "txt",
@@ -138,6 +144,23 @@ export const exportPackageStatuses = [
   "failed"
 ] as const;
 
+export const capabilitySignalStatuses = [
+  "pending_review",
+  "accepted",
+  "rejected"
+] as const;
+
+export const mistakePatternStatuses = [
+  "pending_review",
+  "accepted",
+  "rejected"
+] as const;
+
+export const focusCardStatuses = [
+  "active",
+  "archived"
+] as const;
+
 export const objectPolicyObjectTypes = [
   "passport_snapshot",
   "visa_bundle",
@@ -148,6 +171,7 @@ export const objectPolicyObjectTypes = [
 
 export const sourceTypeSchema = z.enum(sourceTypes);
 export const privacyLevelSchema = z.enum(privacyLevels);
+export const workspaceTypeSchema = z.enum(workspaceTypes);
 export const sourceStatusSchema = z.enum(sourceStatuses);
 export const nodeTypeSchema = z.enum(nodeTypes);
 export const nodeStatusSchema = z.enum(nodeStatuses);
@@ -167,12 +191,21 @@ export const avatarSimulationStatusSchema = z.enum(avatarSimulationStatuses);
 export const avatarLiveSessionStatusSchema = z.enum(avatarLiveSessionStatuses);
 export const avatarLiveMessageRoleSchema = z.enum(avatarLiveMessageRoles);
 export const exportPackageStatusSchema = z.enum(exportPackageStatuses);
+export const capabilitySignalStatusSchema = z.enum(capabilitySignalStatuses);
+export const mistakePatternStatusSchema = z.enum(mistakePatternStatuses);
+export const focusCardStatusSchema = z.enum(focusCardStatuses);
 export const objectPolicyObjectTypeSchema = z.enum(objectPolicyObjectTypes);
+
+export const workspaceCreateSchema = z.object({
+  title: z.string().min(1),
+  workspaceType: workspaceTypeSchema.default("personal")
+});
 
 export const importPayloadSchema = z.object({
   type: sourceTypeSchema,
   title: z.string().min(1),
   originUrl: z.string().url().optional(),
+  workspaceId: z.string().optional(),
   projectKey: z.string().trim().min(1).optional(),
   privacyLevel: privacyLevelSchema.default("L1_LOCAL_AI"),
   textContent: z.string().optional(),
@@ -187,6 +220,7 @@ export const compileRequestSchema = z.object({
 
 export const researchQuerySchema = z.object({
   question: z.string().min(3),
+  workspaceId: z.string().optional(),
   projectKey: z.string().optional(),
   tags: z.array(z.string()).default([]),
   limit: z.number().int().positive().max(20).default(8)
@@ -206,6 +240,7 @@ export const outputCreateSchema = z.object({
 export const postcardCreateSchema = z.object({
   title: z.string().min(1),
   cardType: postcardTypeSchema,
+  workspaceId: z.string().optional(),
   claim: z.string().min(1),
   evidenceSummary: z.string().min(1),
   userView: z.string().min(1),
@@ -216,9 +251,44 @@ export const postcardCreateSchema = z.object({
 
 export const passportGenerateSchema = z.object({
   title: z.string().default("Knowledge Passport"),
+  workspaceId: z.string().optional(),
   includeNodeIds: z.array(z.string()).default([]),
   includePostcardIds: z.array(z.string()).default([]),
   privacyFloor: privacyLevelSchema.default("L1_LOCAL_AI")
+});
+
+export const capabilitySignalCreateSchema = z.object({
+  workspaceId: z.string().min(1),
+  topic: z.string().min(1),
+  observedPractice: z.string().min(1),
+  currentGaps: z.string().min(1),
+  confidence: z.number().min(0).max(1).default(0.5),
+  evidenceNodeIds: z.array(z.string()).default([]),
+  evidenceFragmentIds: z.array(z.string()).default([]),
+  status: capabilitySignalStatusSchema.default("pending_review")
+});
+
+export const mistakePatternCreateSchema = z.object({
+  workspaceId: z.string().min(1),
+  topic: z.string().min(1),
+  description: z.string().min(1),
+  fixSuggestions: z.string().min(1),
+  recurrenceCount: z.number().int().positive().default(1),
+  exampleNodeIds: z.array(z.string()).default([]),
+  exampleFragmentIds: z.array(z.string()).default([]),
+  privacyLevel: privacyLevelSchema.default("L1_LOCAL_AI"),
+  status: mistakePatternStatusSchema.default("pending_review")
+});
+
+export const focusCardCreateSchema = z.object({
+  workspaceId: z.string().min(1),
+  title: z.string().min(1),
+  goal: z.string().min(1),
+  timeframe: z.string().default(""),
+  priority: z.string().default("medium"),
+  successCriteria: z.string().default(""),
+  relatedTopics: z.array(z.string()).default([]),
+  status: focusCardStatusSchema.default("active")
 });
 
 export const visaRedactionSchema = z.object({
@@ -342,6 +412,7 @@ export const backupRestoreSchema = z.object({
 });
 
 export type PrivacyLevel = z.infer<typeof privacyLevelSchema>;
+export type WorkspaceType = z.infer<typeof workspaceTypeSchema>;
 export type SourceType = z.infer<typeof sourceTypeSchema>;
 export type SourceStatus = z.infer<typeof sourceStatusSchema>;
 export type NodeType = z.infer<typeof nodeTypeSchema>;
@@ -362,12 +433,19 @@ export type AvatarSimulationStatus = z.infer<typeof avatarSimulationStatusSchema
 export type AvatarLiveSessionStatus = z.infer<typeof avatarLiveSessionStatusSchema>;
 export type AvatarLiveMessageRole = z.infer<typeof avatarLiveMessageRoleSchema>;
 export type ExportPackageStatus = z.infer<typeof exportPackageStatusSchema>;
+export type CapabilitySignalStatus = z.infer<typeof capabilitySignalStatusSchema>;
+export type MistakePatternStatus = z.infer<typeof mistakePatternStatusSchema>;
+export type FocusCardStatus = z.infer<typeof focusCardStatusSchema>;
 export type ObjectPolicyObjectType = z.infer<typeof objectPolicyObjectTypeSchema>;
+export type WorkspaceCreateInput = z.infer<typeof workspaceCreateSchema>;
 export type ImportPayload = z.infer<typeof importPayloadSchema>;
 export type ResearchQuery = z.infer<typeof researchQuerySchema>;
 export type OutputCreateInput = z.infer<typeof outputCreateSchema>;
 export type PostcardCreateInput = z.infer<typeof postcardCreateSchema>;
 export type PassportGenerateInput = z.infer<typeof passportGenerateSchema>;
+export type CapabilitySignalCreateInput = z.infer<typeof capabilitySignalCreateSchema>;
+export type MistakePatternCreateInput = z.infer<typeof mistakePatternCreateSchema>;
+export type FocusCardCreateInput = z.infer<typeof focusCardCreateSchema>;
 export type VisaRedactionConfig = z.infer<typeof visaRedactionSchema>;
 export type VisaBundleCreateInput = z.infer<typeof visaBundleCreateSchema>;
 export type VisaFeedbackCreateInput = z.infer<typeof visaFeedbackCreateSchema>;
@@ -383,6 +461,57 @@ export type AgentPackExportCreateInput = z.infer<typeof agentPackExportCreateSch
 export type ObjectPolicyUpsertInput = z.infer<typeof objectPolicyUpsertSchema>;
 export type BackupCreateInput = z.infer<typeof backupCreateSchema>;
 export type BackupRestoreInput = z.infer<typeof backupRestoreSchema>;
+
+export type WorkspaceRecord = {
+  id: string;
+  title: string;
+  workspaceType: WorkspaceType;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CapabilitySignal = {
+  id: string;
+  workspaceId: string;
+  topic: string;
+  observedPractice: string;
+  currentGaps: string;
+  confidence: number;
+  evidenceNodeIds: string[];
+  evidenceFragmentIds: string[];
+  status: CapabilitySignalStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MistakePattern = {
+  id: string;
+  workspaceId: string;
+  topic: string;
+  description: string;
+  fixSuggestions: string;
+  recurrenceCount: number;
+  exampleNodeIds: string[];
+  exampleFragmentIds: string[];
+  privacyLevel: PrivacyLevel;
+  status: MistakePatternStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type FocusCard = {
+  id: string;
+  workspaceId: string;
+  title: string;
+  goal: string;
+  timeframe: string;
+  priority: string;
+  successCriteria: string;
+  relatedTopics: string[];
+  status: FocusCardStatus;
+  createdAt: string;
+  updatedAt: string;
+};
 
 export type VisaBundleSummary = {
   id: string;


### PR DESCRIPTION
## Summary
- add workspaces, capability signals, mistake patterns, and focus cards as first-layer context objects
- enrich passport generation and downstream governed layers with the new context model
- reset product framing, navigation, and core UI around an AI-mountable personal knowledge base

## Verification
- npm run verify