### PR TITLE
Polish mount context and demo workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,36 @@ npm run dev:all
 
 - [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 
+## Demo Seed
+
+To create a deterministic demo dataset without calling a live model:
+
+```bash
+npm run demo:seed
+```
+
+This seeds:
+
+- demo sources
+- accepted knowledge nodes
+- capability signals
+- mistake patterns
+- one active focus card
+- one postcard
+- one passport
+- one visa
+- one agent pack
+- one avatar
+- one export package
+
+Recommended walkthrough after seeding:
+
+1. open `/signals`
+2. open `/passport`
+3. open `/visas`
+4. open `/avatars`
+5. open `/exports`
+
 ## Environment
 
 Current variables in `apps/web/.env.example`:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
-    "worker": "tsx scripts/worker.ts"
+    "worker": "tsx scripts/worker.ts",
+    "demo:seed": "tsx scripts/seed-demo.ts"
   },
   "dependencies": {
     "@ai-knowledge-passport/shared": "file:../../packages/shared",

--- a/apps/web/scripts/seed-demo.ts
+++ b/apps/web/scripts/seed-demo.ts
@@ -1,0 +1,297 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { createAgentPackSnapshot } from "@/server/services/agent-packs";
+import { createAvatarProfile } from "@/server/services/avatars";
+import { applyReviewAction, compileSource } from "@/server/services/compiler";
+import { createAgentPackExportPackage } from "@/server/services/exports";
+import { createFocusCard } from "@/server/services/focus-cards";
+import { createPassportSnapshot } from "@/server/services/passports";
+import { createSuggestedPostcard } from "@/server/services/postcards";
+import { reviewCapabilitySignal, reviewMistakePattern, listCapabilitySignals, listMistakePatterns } from "@/server/services/signals";
+import { createSourceImport } from "@/server/services/sources";
+import { createVisaBundle } from "@/server/services/visas";
+import { resolveDatabasePath } from "@/server/db/client";
+import { resolveWorkspaceRoot } from "@/server/utils/workspace";
+
+class DemoProvider implements ModelProvider {
+  readonly isConfigured = true;
+
+  async extractStructured() {
+    return {
+      summary: "Demo summary",
+      keyClaims: ["claim"],
+      concepts: ["context"],
+      themes: ["passport"],
+      tags: ["demo", "passport"]
+    };
+  }
+
+  async summarizeAndLink(input: Parameters<ModelProvider["summarizeAndLink"]>[0]) {
+    return {
+      nodes: [
+        {
+          nodeType: "summary" as const,
+          title: `${input.title} summary`,
+          summary: input.text.slice(0, 120),
+          bodyMd: `# ${input.title}\n\n${input.text}`,
+          tags: input.tags.length ? input.tags : ["demo", "passport"]
+        }
+      ],
+      relationHints: []
+    };
+  }
+
+  async embedText(input: string[]) {
+    return input.map((entry) => {
+      const chars = Array.from(entry).slice(0, 8).map((char) => char.charCodeAt(0) / 255);
+      while (chars.length < 8) chars.push(0);
+      return chars;
+    });
+  }
+
+  async transcribeAudio() {
+    return "demo transcript";
+  }
+
+  async generateAnswer() {
+    return { answerMd: "demo answer", citations: [] };
+  }
+
+  async generateCard(input: Parameters<ModelProvider["generateCard"]>[0]) {
+    return {
+      claim: `AI should read ${input.title} as a compact governed context card.`,
+      evidenceSummary: "Grounded in accepted local knowledge and current focus.",
+      userView: "This card helps an external AI adapt faster."
+    };
+  }
+
+  async generatePassport(input: Parameters<ModelProvider["generatePassport"]>[0]) {
+    return {
+      humanMarkdown: [
+        `# ${input.title}`,
+        "",
+        input.focusCard ? `## Active Focus\n\n- ${input.focusCard.title}\n- ${input.focusCard.goal}` : "## Active Focus\n\n- none",
+        "",
+        "## Capability Signals",
+        ...input.capabilitySignals.map((signal) => `- ${signal.topic}: ${signal.observedPractice}`),
+        "",
+        "## Blind Spots",
+        ...input.mistakePatterns.map((mistake) => `- ${mistake.topic}: ${mistake.description}`)
+      ].join("\n"),
+      machineManifest: {
+        title: input.title,
+        capabilitySignals: input.capabilitySignals,
+        mistakePatterns: input.mistakePatterns,
+        focusCard: input.focusCard
+      }
+    };
+  }
+
+  async generateLearnerState(input: Parameters<ModelProvider["generateLearnerState"]>[0]) {
+    return {
+      capabilitySignals: [
+        {
+          topic: "AI context framing",
+          observedPractice: "Can organize knowledge into a mountable passport entry layer.",
+          currentGaps: "Needs stronger defaults for current-goal prioritization.",
+          confidence: 0.74,
+          evidenceNodeIds: input.nodes.slice(0, 1).map((node) => node.id),
+          evidenceFragmentIds: input.claims.slice(0, 1).flatMap((claim) => claim.sourceFragmentIds)
+        }
+      ],
+      mistakePatterns: [
+        {
+          topic: "Over-explaining",
+          description: "Tends to describe the whole system before clarifying the first user value.",
+          fixSuggestions: "Lead with the passport as the default AI entry point.",
+          recurrenceCount: 2,
+          exampleNodeIds: input.nodes.slice(0, 1).map((node) => node.id),
+          exampleFragmentIds: input.claims.slice(0, 1).flatMap((claim) => claim.sourceFragmentIds),
+          privacyLevel: "L1_LOCAL_AI" as const
+        }
+      ]
+    };
+  }
+
+  async generateAvatarReply() {
+    return { answerMd: "demo avatar answer", citations: [] };
+  }
+}
+
+function resolveDataDir(rootDir: string) {
+  return process.env.AIKP_DATA_DIR ? path.resolve(process.env.AIKP_DATA_DIR) : path.join(rootDir, "data");
+}
+
+async function main() {
+  const rootDir = resolveWorkspaceRoot();
+  const dataDir = resolveDataDir(rootDir);
+  fs.mkdirSync(path.join(dataDir, "objects"), { recursive: true });
+  fs.mkdirSync(path.join(dataDir, "exports"), { recursive: true });
+  fs.mkdirSync(path.join(dataDir, "backups"), { recursive: true });
+
+  const context = createAppContext({
+    dataDir,
+    databasePath: resolveDatabasePath(),
+    provider: new DemoProvider()
+  });
+
+  const existing = await context.db.query.passportSnapshots.findFirst({
+    where: (table, { eq }) => eq(table.title, "Demo Passport")
+  });
+
+  if (existing) {
+    console.log(`Demo data already exists: ${existing.id}`);
+    return;
+  }
+
+  const imports = await Promise.all([
+    createSourceImport(context, {
+      payload: {
+        type: "markdown",
+        title: "Demo Source: Foundation",
+        workspaceId: "ws_personal",
+        privacyLevel: "L1_LOCAL_AI",
+        textContent: "A good AI knowledge passport helps the model understand the user's foundation before answering.",
+        tags: ["demo", "passport", "foundation"],
+        metadata: {}
+      }
+    }),
+    createSourceImport(context, {
+      payload: {
+        type: "markdown",
+        title: "Demo Source: Current Goal",
+        workspaceId: "ws_personal",
+        privacyLevel: "L1_LOCAL_AI",
+        textContent: "The current goal is to make the passport the default AI entry object and keep writeback candidate-only.",
+        tags: ["demo", "focus", "goal"],
+        metadata: {}
+      }
+    }),
+    createSourceImport(context, {
+      payload: {
+        type: "markdown",
+        title: "Demo Source: Blind Spot",
+        workspaceId: "ws_personal",
+        privacyLevel: "L1_LOCAL_AI",
+        textContent: "The common failure mode is over-scoping the product before the first user pain is sharp.",
+        tags: ["demo", "blind-spot", "scope"],
+        metadata: {}
+      }
+    })
+  ]);
+
+  const acceptedNodeIds: string[] = [];
+  for (const imported of imports) {
+    const nodes = await compileSource(context, imported.sourceId);
+    for (const node of nodes) {
+      await applyReviewAction(context, {
+        nodeId: node.id,
+        action: "accept"
+      });
+      acceptedNodeIds.push(node.id);
+    }
+  }
+
+  const pendingSignals = await listCapabilitySignals(context, { workspaceId: "ws_personal", status: "pending_review" });
+  const pendingMistakes = await listMistakePatterns(context, { workspaceId: "ws_personal", status: "pending_review" });
+
+  for (const signal of pendingSignals) {
+    await reviewCapabilitySignal(context, signal.id, "accepted");
+  }
+  for (const mistake of pendingMistakes) {
+    await reviewMistakePattern(context, mistake.id, "accepted");
+  }
+
+  await createFocusCard(context, {
+    workspaceId: "ws_personal",
+    title: "Demo Focus",
+    goal: "Show that an AI can read a passport and adapt to the user without repeated explanation.",
+    timeframe: "This week",
+    priority: "high",
+    successCriteria: "The mounted AI starts from the right context and stays inside bounds.",
+    relatedTopics: ["passport", "mount", "avatar"],
+    status: "active"
+  });
+
+  const postcard = await createSuggestedPostcard(context, {
+    cardType: "knowledge",
+    title: "Demo Passport Card",
+    nodeIds: acceptedNodeIds,
+    sourceIds: imports.map((item) => item.sourceId)
+  });
+
+  const passportId = await createPassportSnapshot(context, {
+    title: "Demo Passport",
+    workspaceId: "ws_personal",
+    includeNodeIds: acceptedNodeIds,
+    includePostcardIds: [postcard.postcardId],
+    privacyFloor: "L1_LOCAL_AI"
+  });
+
+  const visa = await createVisaBundle(context, {
+    title: "Demo Mount Visa",
+    passportId,
+    includeNodeIds: [],
+    includePostcardIds: [],
+    privacyFloor: "L1_LOCAL_AI",
+    audienceLabel: "Demo AI mount",
+    description: "A read-only demo bundle derived from the passport.",
+    purpose: "Show how a downstream AI would mount only the right context.",
+    allowMachineDownload: true,
+    redaction: {
+      hideOriginUrls: false,
+      hideSourcePaths: true,
+      hideRawSourceIds: false
+    }
+  });
+
+  const pack = await createAgentPackSnapshot(context, {
+    title: "Demo Agent Pack",
+    passportId,
+    visaId: undefined,
+    includeNodeIds: [],
+    includePostcardIds: [],
+    privacyFloor: "L1_LOCAL_AI"
+  });
+
+  const avatar = await createAvatarProfile(context, {
+    title: "Demo Avatar",
+    activePackId: pack.packId,
+    intro: "You are a governed demo avatar that starts from passport context.",
+    toneRules: ["clear", "evidence-first"],
+    forbiddenTopics: ["pricing", "confidential strategy"],
+    escalationRules: {
+      escalateOnForbiddenTopic: true,
+      escalateOnInsufficientEvidence: true,
+      escalateOnOutOfScope: true
+    },
+    status: "active"
+  });
+
+  const exportPackage = await createAgentPackExportPackage(context, {
+    agentPackId: pack.packId,
+    avatarProfileId: avatar.avatarId,
+    includeAvatarProfile: true
+  });
+
+  console.log(JSON.stringify({
+    workspaceId: "ws_personal",
+    sourceIds: imports.map((item) => item.sourceId),
+    acceptedNodeIds,
+    postcardId: postcard.postcardId,
+    passportId,
+    visaId: visa.visaId,
+    visaPath: visa.secretPath,
+    agentPackId: pack.packId,
+    avatarId: avatar.avatarId,
+    exportId: exportPackage.exportId
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,58 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
 
 export default function HomePage() {
-  redirect("/dashboard");
+  return (
+    <main className="min-h-screen bg-[var(--surface)]">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center gap-10 px-6 py-16">
+        <div className="max-w-3xl">
+          <p className="text-xs uppercase tracking-[0.28em] text-[var(--muted)]">AI-Mountable Personal Knowledge Base</p>
+          <h1 className="mt-4 text-5xl font-semibold tracking-tight text-[var(--ink)]">
+            Help any AI understand your foundation, current goal, and blind spots without starting from zero.
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-[var(--muted)]">
+            This system compiles private materials into signals, postcards, passports, visas, governed avatars, and export bundles. The passport is the canonical AI entry object. Everything deeper stays explicitly authorized.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <Link href="/dashboard" className="rounded-full bg-[var(--accent)] px-6 py-3 text-sm font-medium text-white">
+            Open Dashboard
+          </Link>
+          <Link href="/signals" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
+            Open Signals
+          </Link>
+          <Link href="/passport" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
+            Open Passport
+          </Link>
+          <Link href="/visas" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
+            Open Mount Center
+          </Link>
+        </div>
+
+        <section className="grid gap-6 lg:grid-cols-3">
+          <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">
+            <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Core Loop</p>
+            <p className="mt-4 text-xl font-semibold">Import {"->"} Compile {"->"} Signals {"->"} Passport</p>
+            <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+              Turn raw sources into accepted knowledge, capability signals, mistake patterns, and an active focus card before any AI reads deeper.
+            </p>
+          </article>
+          <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">
+            <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Mount Layer</p>
+            <p className="mt-4 text-xl font-semibold">Passport {"->"} Visa {"->"} Feedback</p>
+            <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+              Narrow the passport into a read-only visa bundle with logs, expiry, redaction, and lightweight external flowback.
+            </p>
+          </article>
+          <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">
+            <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Governed AI</p>
+            <p className="mt-4 text-xl font-semibold">Agent Pack {"->"} Avatar {"->"} Export</p>
+            <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+              Bind bounded context to avatars, run governed sessions, and export cross-AI bundles without exposing the whole local base.
+            </p>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
 }

--- a/apps/web/src/app/v/[token]/page.tsx
+++ b/apps/web/src/app/v/[token]/page.tsx
@@ -52,6 +52,15 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
   }
 
   const visa = access.visa;
+  const passportContext = visa.machineManifest && typeof visa.machineManifest === "object"
+    ? (visa.machineManifest as {
+        passportContext?: {
+          focusCard?: { title?: string; goal?: string } | null;
+          capabilitySignals?: Array<{ topic?: string; observedPractice?: string; currentGaps?: string }>;
+          mistakePatterns?: Array<{ topic?: string; description?: string }>;
+        };
+      }).passportContext ?? null
+    : null;
 
   return (
     <main className="mx-auto min-h-screen max-w-5xl px-5 py-10">
@@ -75,6 +84,7 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
                 ? `machine downloads ${visa.machineDownloadCount}/${visa.maxMachineDownloads}`
                 : `machine downloads ${visa.machineDownloadCount}`}
             </StatusBadge>
+            <StatusBadge>read-only</StatusBadge>
           </div>
           {visa.allowMachineDownload ? (
             <a className="mt-6 inline-flex rounded-full border border-[var(--line)] px-4 py-2 text-sm" href={visa.machinePath ?? "#"}>
@@ -82,6 +92,44 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
             </a>
           ) : null}
         </section>
+
+        {passportContext ? (
+          <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-8">
+            <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Mounted context</p>
+            <h2 className="mt-3 text-2xl font-semibold">What this AI should understand first</h2>
+            <div className="mt-6 grid gap-6 lg:grid-cols-3">
+              <div className="rounded-3xl border border-[var(--line)] bg-white/60 p-5">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Active Focus</p>
+                <p className="mt-3 text-sm font-medium">{passportContext.focusCard?.title ?? "No active focus"}</p>
+                {passportContext.focusCard?.goal ? <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{passportContext.focusCard.goal}</p> : null}
+              </div>
+              <div className="rounded-3xl border border-[var(--line)] bg-white/60 p-5">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Capability Signals</p>
+                <div className="mt-3 space-y-3">
+                  {(passportContext.capabilitySignals ?? []).slice(0, 3).map((signal, index) => (
+                    <article key={`${signal.topic ?? "signal"}-${index}`} className="text-sm">
+                      <p className="font-medium">{signal.topic ?? "Untitled"}</p>
+                      <p className="mt-1 text-[var(--muted)]">{signal.observedPractice ?? ""}</p>
+                    </article>
+                  ))}
+                  {(passportContext.capabilitySignals ?? []).length === 0 ? <p className="text-sm text-[var(--muted)]">No signals included.</p> : null}
+                </div>
+              </div>
+              <div className="rounded-3xl border border-[var(--line)] bg-white/60 p-5">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted)]">Blind Spots</p>
+                <div className="mt-3 space-y-3">
+                  {(passportContext.mistakePatterns ?? []).slice(0, 3).map((mistake, index) => (
+                    <article key={`${mistake.topic ?? "mistake"}-${index}`} className="text-sm">
+                      <p className="font-medium">{mistake.topic ?? "Untitled"}</p>
+                      <p className="mt-1 text-[var(--muted)]">{mistake.description ?? ""}</p>
+                    </article>
+                  ))}
+                  {(passportContext.mistakePatterns ?? []).length === 0 ? <p className="text-sm text-[var(--muted)]">No blind spots included.</p> : null}
+                </div>
+              </div>
+            </div>
+          </section>
+        ) : null}
 
         <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-8">
           <div className="prose prose-sm max-w-none">

--- a/apps/web/src/app/visas/[id]/page.tsx
+++ b/apps/web/src/app/visas/[id]/page.tsx
@@ -37,6 +37,16 @@ export default async function VisaDetailPage(props: { params: Promise<{ id: stri
     );
   }
 
+  const passportContext = visa.machineManifest && typeof visa.machineManifest === "object"
+    ? (visa.machineManifest as {
+        passportContext?: {
+          focusCard?: { title?: string } | null;
+          capabilitySignals?: unknown[];
+          mistakePatterns?: unknown[];
+        };
+      }).passportContext ?? null
+    : null;
+
   return (
     <PageShell currentPath="/visas" title="Visa Detail" subtitle="Inspect policy, access state, and external flowback for a single scenario bundle">
       <section className="grid gap-4 md:grid-cols-4">
@@ -129,6 +139,13 @@ export default async function VisaDetailPage(props: { params: Promise<{ id: stri
             <div className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">
               <p className="font-medium">Postcards</p>
               <p className="mt-2 text-[var(--muted)]">{visa.includePostcardIds.length}</p>
+            </div>
+            <div className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">
+              <p className="font-medium">Inherited Passport Context</p>
+              <p className="mt-2 text-[var(--muted)]">
+                Focus {passportContext?.focusCard?.title ?? "none"} · Signals {Array.isArray(passportContext?.capabilitySignals) ? passportContext.capabilitySignals.length : 0} · Blind spots{" "}
+                {Array.isArray(passportContext?.mistakePatterns) ? passportContext.mistakePatterns.length : 0}
+              </p>
             </div>
           </div>
         </SectionCard>

--- a/apps/web/src/server/services/visas.ts
+++ b/apps/web/src/server/services/visas.ts
@@ -207,6 +207,11 @@ function renderVisaHumanMarkdown(input: {
   description: string;
   purpose: string;
   expiresAt?: string | null;
+  passportContext?: {
+    focusCard?: { title?: string; goal?: string } | null;
+    capabilitySignals?: Array<{ topic?: string; observedPractice?: string; currentGaps?: string }>;
+    mistakePatterns?: Array<{ topic?: string; description?: string }>;
+  } | null;
   nodes: VisaNode[];
   cards: VisaPostcard[];
   sourceMap: Map<string, typeof sources.$inferSelect>;
@@ -226,6 +231,33 @@ function renderVisaHumanMarkdown(input: {
 
   if (input.purpose.trim()) {
     lines.push("", `Purpose: ${input.purpose.trim()}`);
+  }
+
+  if (input.passportContext) {
+    const focusTitle = input.passportContext.focusCard?.title;
+    const focusGoal = input.passportContext.focusCard?.goal;
+    const signals = input.passportContext.capabilitySignals ?? [];
+    const mistakes = input.passportContext.mistakePatterns ?? [];
+
+    lines.push("", "## Passport Context");
+    lines.push("", `Active focus: ${focusTitle ?? "none"}`);
+    if (focusGoal) {
+      lines.push("", `Goal: ${focusGoal}`);
+    }
+
+    if (signals.length) {
+      lines.push("", "### Capability Signals");
+      for (const signal of signals.slice(0, 5)) {
+        lines.push("", `- ${signal.topic ?? "Untitled"}: ${signal.observedPractice ?? ""}${signal.currentGaps ? ` | Gaps: ${signal.currentGaps}` : ""}`);
+      }
+    }
+
+    if (mistakes.length) {
+      lines.push("", "### Blind Spots");
+      for (const mistake of mistakes.slice(0, 5)) {
+        lines.push("", `- ${mistake.topic ?? "Untitled"}: ${mistake.description ?? ""}`);
+      }
+    }
   }
 
   if (input.cards.length) {
@@ -273,6 +305,7 @@ function buildVisaMachineManifest(input: {
   title: string;
   audienceLabel: string;
   passportId: string | null;
+  passportContext: Record<string, unknown> | null;
   description: string;
   purpose: string;
   privacyFloor: PrivacyLevel;
@@ -291,6 +324,7 @@ function buildVisaMachineManifest(input: {
     title: input.title,
     audienceLabel: input.audienceLabel,
     sourcePassportId: input.passportId,
+    passportContext: input.passportContext,
     description: input.description,
     purpose: input.purpose,
     generatedAt: nowIso(),
@@ -333,6 +367,7 @@ async function loadPassportFallback(
   if (!passportId) {
     return {
       passportTitle: null,
+      passportContext: null,
       resolvedNodeIds: includeNodeIds,
       resolvedPostcardIds: includePostcardIds
     };
@@ -350,6 +385,7 @@ async function loadPassportFallback(
 
   return {
     passportTitle: passport.title,
+    passportContext: JSON.parse(passport.machineManifestJson) as Record<string, unknown>,
     resolvedNodeIds: usePassportSnapshot ? parseJsonArray<string>(passport.includeNodeIdsJson) : includeNodeIds,
     resolvedPostcardIds: usePassportSnapshot ? parseJsonArray<string>(passport.includePostcardIdsJson) : includePostcardIds
   };
@@ -412,6 +448,7 @@ async function loadVisaContent(context: AppContext, input: VisaBundleCreateInput
 
   return {
     passportTitle: fallback.passportTitle,
+    passportContext: fallback.passportContext,
     nodes,
     cards
   };
@@ -674,6 +711,11 @@ export async function createVisaBundle(context: AppContext, input: VisaBundleCre
     title: input.title,
     audienceLabel: input.audienceLabel,
     passportTitle: content.passportTitle,
+    passportContext: content.passportContext as {
+      focusCard?: { title?: string; goal?: string } | null;
+      capabilitySignals?: Array<{ topic?: string; observedPractice?: string; currentGaps?: string }>;
+      mistakePatterns?: Array<{ topic?: string; description?: string }>;
+    } | null,
     description: input.description,
     purpose: input.purpose,
     expiresAt: input.expiresAt ?? null,
@@ -687,6 +729,7 @@ export async function createVisaBundle(context: AppContext, input: VisaBundleCre
     title: input.title,
     audienceLabel: input.audienceLabel,
     passportId: input.passportId ?? null,
+    passportContext: content.passportContext ?? null,
     description: input.description,
     purpose: input.purpose,
     privacyFloor: effectivePrivacyFloor,

--- a/apps/web/src/server/tests/release-smoke.test.ts
+++ b/apps/web/src/server/tests/release-smoke.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ModelProvider } from "@/server/providers/model-provider";
+import { createAppContext } from "@/server/context";
+import { createAgentPackSnapshot } from "@/server/services/agent-packs";
+import { createAvatarProfile, simulateAvatar } from "@/server/services/avatars";
+import { applyReviewAction, compileSource } from "@/server/services/compiler";
+import { createAgentPackExportPackage, getExportPackage } from "@/server/services/exports";
+import { createFocusCard } from "@/server/services/focus-cards";
+import { createPassportSnapshot } from "@/server/services/passports";
+import { createSuggestedPostcard } from "@/server/services/postcards";
+import { reviewCapabilitySignal, reviewMistakePattern, listCapabilitySignals, listMistakePatterns } from "@/server/services/signals";
+import { createSourceImport } from "@/server/services/sources";
+import { createVisaBundle } from "@/server/services/visas";
+
+import { describe, expect, it } from "vitest";
+
+class SmokeProvider implements ModelProvider {
+  readonly isConfigured = true;
+
+  async extractStructured() {
+    return { summary: "summary", keyClaims: ["claim"], concepts: ["concept"], themes: ["theme"], tags: ["demo"] };
+  }
+
+  async summarizeAndLink(input: Parameters<ModelProvider["summarizeAndLink"]>[0]) {
+    return {
+      nodes: [
+        {
+          nodeType: "summary" as const,
+          title: `${input.title} summary`,
+          summary: input.text.slice(0, 100),
+          bodyMd: input.text,
+          tags: input.tags.length ? input.tags : ["demo"]
+        }
+      ],
+      relationHints: []
+    };
+  }
+
+  async embedText(input: string[]) {
+    return input.map((entry) => Array.from(entry).slice(0, 6).map((char) => char.charCodeAt(0) / 255));
+  }
+
+  async transcribeAudio() {
+    return "audio";
+  }
+
+  async generateAnswer() {
+    return { answerMd: "answer", citations: [] };
+  }
+
+  async generateCard() {
+    return {
+      claim: "A passport gives an AI the right starting context.",
+      evidenceSummary: "Grounded in accepted nodes.",
+      userView: "This is the compact outward layer."
+    };
+  }
+
+  async generatePassport(input: Parameters<ModelProvider["generatePassport"]>[0]) {
+    return {
+      humanMarkdown: `# ${input.title}\n\n${input.focusCard ? input.focusCard.title : "no focus"}`,
+      machineManifest: {
+        focusCard: input.focusCard,
+        capabilitySignals: input.capabilitySignals,
+        mistakePatterns: input.mistakePatterns
+      }
+    };
+  }
+
+  async generateLearnerState(input: Parameters<ModelProvider["generateLearnerState"]>[0]) {
+    return {
+      capabilitySignals: [
+        {
+          topic: "Context packaging",
+          observedPractice: "Can organize knowledge into an AI-readable passport.",
+          currentGaps: "Needs stronger mount defaults.",
+          confidence: 0.71,
+          evidenceNodeIds: input.nodes.map((node) => node.id).slice(0, 1),
+          evidenceFragmentIds: input.claims.flatMap((claim) => claim.sourceFragmentIds).slice(0, 1)
+        }
+      ],
+      mistakePatterns: [
+        {
+          topic: "Over-scoping",
+          description: "Can still explain too much before clarifying the first value.",
+          fixSuggestions: "Lead with the passport and current focus.",
+          recurrenceCount: 1,
+          exampleNodeIds: input.nodes.map((node) => node.id).slice(0, 1),
+          exampleFragmentIds: input.claims.flatMap((claim) => claim.sourceFragmentIds).slice(0, 1),
+          privacyLevel: "L1_LOCAL_AI" as const
+        }
+      ]
+    };
+  }
+
+  async generateAvatarReply(input: Parameters<ModelProvider["generateAvatarReply"]>[0]) {
+    return {
+      answerMd: `Avatar reply: ${input.evidence[0]?.text ?? ""}`,
+      citations: input.evidence.slice(0, 1).map((entry) => ({
+        refId: entry.refId,
+        kind: "wiki_node" as const,
+        excerpt: entry.text.slice(0, 80),
+        score: 0.9
+      }))
+    };
+  }
+}
+
+describe("release smoke", () => {
+  it("runs the full context -> passport -> mount -> agent -> export chain", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "akp-release-smoke-"));
+    const dataDir = path.join(tempRoot, "data");
+    await fs.mkdir(path.join(dataDir, "objects"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "exports"), { recursive: true });
+    await fs.mkdir(path.join(dataDir, "backups"), { recursive: true });
+
+    const context = createAppContext({
+      dataDir,
+      databasePath: path.join(dataDir, "test.sqlite"),
+      provider: new SmokeProvider()
+    });
+
+    const imported = await createSourceImport(context, {
+      payload: {
+        type: "markdown",
+        title: "Smoke source",
+        workspaceId: "ws_personal",
+        privacyLevel: "L1_LOCAL_AI",
+        textContent: "A passport helps an AI understand the user quickly under authorization.",
+        tags: ["passport", "smoke"],
+        metadata: {}
+      }
+    });
+
+    const nodes = await compileSource(context, imported.sourceId);
+    await applyReviewAction(context, {
+      nodeId: nodes[0]!.id,
+      action: "accept"
+    });
+
+    const [pendingSignals, pendingMistakes] = await Promise.all([
+      listCapabilitySignals(context, { workspaceId: "ws_personal", status: "pending_review" }),
+      listMistakePatterns(context, { workspaceId: "ws_personal", status: "pending_review" })
+    ]);
+
+    await reviewCapabilitySignal(context, pendingSignals[0]!.id, "accepted");
+    await reviewMistakePattern(context, pendingMistakes[0]!.id, "accepted");
+
+    await createFocusCard(context, {
+      workspaceId: "ws_personal",
+      title: "Smoke focus",
+      goal: "Package a clean AI entry object.",
+      timeframe: "today",
+      priority: "high",
+      successCriteria: "A downstream AI starts from the right context.",
+      relatedTopics: ["passport"],
+      status: "active"
+    });
+
+    const postcard = await createSuggestedPostcard(context, {
+      cardType: "knowledge",
+      title: "Smoke postcard",
+      nodeIds: [nodes[0]!.id],
+      sourceIds: [imported.sourceId]
+    });
+
+    const passportId = await createPassportSnapshot(context, {
+      title: "Smoke passport",
+      workspaceId: "ws_personal",
+      includeNodeIds: [nodes[0]!.id],
+      includePostcardIds: [postcard.postcardId],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+
+    const visa = await createVisaBundle(context, {
+      title: "Smoke visa",
+      passportId,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI",
+      audienceLabel: "smoke test",
+      description: "",
+      purpose: "",
+      allowMachineDownload: true,
+      redaction: {
+        hideOriginUrls: false,
+        hideSourcePaths: false,
+        hideRawSourceIds: false
+      }
+    });
+
+    const pack = await createAgentPackSnapshot(context, {
+      title: "Smoke pack",
+      passportId,
+      visaId: undefined,
+      includeNodeIds: [],
+      includePostcardIds: [],
+      privacyFloor: "L1_LOCAL_AI"
+    });
+
+    const avatar = await createAvatarProfile(context, {
+      title: "Smoke avatar",
+      activePackId: pack.packId,
+      intro: "Use the passport context first.",
+      toneRules: ["clear"],
+      forbiddenTopics: [],
+      escalationRules: {
+        escalateOnForbiddenTopic: true,
+        escalateOnInsufficientEvidence: true,
+        escalateOnOutOfScope: true
+      },
+      status: "active"
+    });
+
+    const simulation = await simulateAvatar(context, avatar.avatarId, {
+      question: "How does the passport help an AI understand the user?"
+    });
+
+    expect(simulation.resultStatus).toBe("answered");
+
+    const exported = await createAgentPackExportPackage(context, {
+      agentPackId: pack.packId,
+      avatarProfileId: avatar.avatarId,
+      includeAvatarProfile: true
+    });
+
+    const exportPackage = await getExportPackage(context, exported.exportId);
+    expect(visa.secretPath).toContain("/v/");
+    expect(exportPackage?.objectId).toBe(pack.packId);
+    expect((exportPackage?.manifest as { passportContext?: unknown }).passportContext).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "npm run dev -w @ai-knowledge-passport/web",
     "worker": "npm run worker -w @ai-knowledge-passport/web",
     "dev:all": "concurrently \"npm run dev -w @ai-knowledge-passport/web\" \"npm run worker -w @ai-knowledge-passport/web\"",
+    "demo:seed": "npm run demo:seed -w @ai-knowledge-passport/web",
     "build": "npm run build -w @ai-knowledge-passport/web",
     "typecheck": "npm run typecheck -w @ai-knowledge-passport/shared && npm run typecheck -w @ai-knowledge-passport/web",
     "test": "npm run test -w @ai-knowledge-passport/web",


### PR DESCRIPTION
## Summary
- carry passport context into visa/public mount surfaces
- add a real landing page and demo seed workflow
- add a release smoke test for the full context-to-governed-AI chain

## Verification
- npm run verify
- AIKP_DATA_DIR=/tmp/ai-note-demo-data AIKP_DATABASE_PATH=/tmp/ai-note-demo-data/demo.sqlite npm run demo:seed