### PR TITLE
[codex] Add control-doc bundle

### DIFF
--- a/.agents/skills/compiler-bench-loop/SKILL.md
+++ b/.agents/skills/compiler-bench-loop/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: compiler-bench-loop
+description: Run a bounded benchmark-driven optimization loop for one compiler or passport-generation module after a fixed evaluator exists. Use only when explicitly asked and when fixtures and guardrails are already implemented. Do not use for normal feature work or before the evaluator exists.
+---
+
+# Compiler Bench Loop
+
+Your job is to run a small, disciplined optimization loop.
+
+## Preconditions
+
+All must be true:
+
+- evaluator exists
+- fixtures exist
+- writable scope is explicitly named
+- human explicitly requested optimization work
+
+If any precondition fails, stop and say why.
+
+## Protocol
+
+1. Re-read `docs/research/program.md` and `docs/research/eval_contract.md`.
+2. Confirm the writable scope.
+3. Create or switch to a dedicated research branch.
+4. Make one coherent change only.
+5. Run the evaluator.
+6. Record a structured row in `results.tsv`.
+7. Keep the change only if promotion rules pass.
+8. Otherwise discard the change.
+
+## Limits
+
+- max 3 experiments
+- no fixture edits
+- no evaluator edits
+- no infinite loop
+- no widening writable scope without updating the plan
+
+## Output
+
+At the end, report:
+- experiments attempted
+- kept vs discarded result
+- metric summary
+- remaining improvement ideas

--- a/.agents/skills/evidence-trace-review/SKILL.md
+++ b/.agents/skills/evidence-trace-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: evidence-trace-review
+description: Review changes that touch compiler, passport, access control, or writeback behavior. Use this when a diff may affect provenance, privacy, permissions, or review gates. Do not use it for unrelated cosmetic changes.
+---
+
+# Evidence Trace Review
+
+Your job is to review high-risk diffs for trust-boundary and provenance regressions.
+
+## Inputs
+
+- current diff
+- `AGENTS.md`
+- `docs/spec/Prompt.md`
+- `docs/spec/Borrowed_Patterns_and_Risks.md`
+- `docs/review/code_review.md`
+
+## Review checklist
+
+1. Is the default outside-AI surface still narrow?
+2. Can high-level artifacts still trace back to evidence and sources?
+3. Did any change introduce hard capability scoring or unjustified inference?
+4. Is there any new auto-merge path from outside AI to canonical knowledge?
+5. Are revoke/expiry/audit paths preserved?
+6. Did the diff widen access to raw sources or the whole workspace?
+7. Does the UI or schema reintroduce concept overload?
+
+## Output format
+
+Return:
+- PASS or FAIL
+- a short list of critical findings
+- a short list of suggested fixes

--- a/.agents/skills/repo-recon/SKILL.md
+++ b/.agents/skills/repo-recon/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: repo-recon
+description: Inventory a repository before implementation. Use this when the real stack, commands, module boundaries, or test harness are unknown or when you must adapt a product spec to an existing repo. Do not use this skill for routine coding once repo inventory is already documented.
+---
+
+# Repo Recon
+
+Your job is to produce a reliable repo inventory before meaningful code changes.
+
+## Inputs
+
+- current working tree
+- `AGENTS.md`
+- `PLANS.md`
+- `plans/mvp_execplan.md`
+- `docs/spec/Prompt.md`
+
+## Steps
+
+1. Find package manifests, task runners, CI files, migration tools, and test runners.
+2. Identify the real module boundaries already present in the repo.
+3. Determine the canonical commands for install, format, lint, typecheck, test, build, migrate, and seed.
+4. Identify the best insertion points for:
+   - domain/schema
+   - compile pipeline
+   - passport generation
+   - gateway/access control
+   - review/audit logic
+   - thin UI
+5. Write findings into `docs/spec/Documentation.md`.
+6. Update `plans/mvp_execplan.md` with discovered commands and insertion points.
+7. Summarize blockers and unresolved assumptions.
+
+## Hard rules
+
+- prefer reading over editing
+- do not implement product features
+- do not invent commands that the repo does not support
+- if the repo already has an equivalent module, recommend extending it instead of duplicating it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,295 @@
+# AGENTS.md
+
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+## Mission
+
+Build the MVP of **AI知识护照盘 / AI Passport**: a compiled, local-first, AI-mountable personal knowledge system that helps outside AI understand a person faster and more accurately through a **Passport manifest**, a **Focus Card**, and a small number of representative **Topic Cards**, rather than forcing the model to rediscover context from raw notes every time.
+
+## Product identity
+
+This product is:
+
+- compiled-knowledge-first
+- passport-first and postcard-first
+- read-only-first for outside AI
+- evidence-backed
+- goal-aware
+- review-gated for writebacks
+- auditable, revocable, and time-bounded
+- model-agnostic
+
+This product is **not**:
+
+- a generic note-taking app
+- a full wiki UI as the primary user experience
+- a team wiki or social knowledge graph
+- a model training or fine-tuning platform
+- an autonomous multi-agent swarm
+- a full-workspace search surface for outside AI by default
+- an auto-merge memory sink
+- a “capability score” product
+
+## Primary user value
+
+The first pain to solve is simple:
+
+**When the user switches AI, tasks, or contexts, they should not need to repeatedly explain who they are, what they know, what they are doing now, and where they are stuck.**
+
+The MVP succeeds only if outside AI can help faster and more accurately after reading the Passport than in an empty chat.
+
+## Borrowed operating principles
+
+Adopt these patterns deliberately:
+
+1. **Compiled middle layer over query-time-only retrieval**
+   Preserve raw sources, then compile them into reusable, inspectable artifacts.
+
+2. **Bounded research loops, not infinite autonomy**
+   If optimizing the compiler, use fixed fixtures, a narrow writable scope, a result ledger, and explicit keep/discard rules.
+
+3. **Plan -> apply -> verify**
+   Separate exploration/planning from implementation and from review.
+
+4. **Capability signals, not capability claims**
+   Never infer a hard skill score from notes or projects alone.
+
+5. **Default narrow surface**
+   Outside AI starts with Passport + Focus Card + representative Topic Cards, not the whole workspace.
+
+## Critical anti-patterns
+
+Do **not** drift into these traps:
+
+- turning the product into a giant markdown wiki UI
+- exposing too many metaphors or top-level objects in P0
+- equating note volume with skill or competence
+- widening outside-AI default access “for convenience”
+- auto-merging outside-AI outputs into canonical knowledge
+- inventing a large runtime platform before proving the product loop
+- copying proprietary runtime features from other agents as if they exist here
+- starting autonomous improvement loops before a fixed evaluator exists
+- optimizing one scalar metric while degrading safety, evidence traceability, or token budget
+
+## User-facing objects for P0
+
+Treat these as the only three primary user-facing objects in P0:
+
+- **Passport**: top-level entry point for outside AI
+- **Focus Card**: what the user is trying to solve now
+- **Topic Card**: compact summary of one topic’s knowns, practice, gaps, questions, and evidence
+
+Internally, you may still model:
+
+- sources
+- evidence fragments
+- knowledge nodes
+- capability signals
+- mistake patterns
+- postcards
+- passports
+- visa bundles
+- mount sessions
+- writeback candidates
+- audit logs
+
+But do **not** force all internal objects into top-level navigation or user vocabulary.
+
+## Non-negotiable MVP invariants
+
+These are hard constraints:
+
+- Raw sources remain the provenance source of truth.
+- Every high-level summary must trace back to one or more evidence fragments.
+- Outside AI reads the **Passport manifest** first.
+- The active **Focus Card** is always accessible from the Passport.
+- Deeper access requires an explicit **Visa Bundle**.
+- Outside AI may create **writeback candidates** only.
+- Canonical knowledge never changes automatically from outside-AI output.
+- P0 permissions stay limited to:
+  - `passport_read`
+  - `topic_read`
+  - `writeback_candidate`
+- Cold start optimizes for **3-5 representative cards**, not a full knowledge graph.
+- Access must be revocable, auditable, and time-bounded.
+- Prefer structured evaluation artifacts over raw chatty experiment logs.
+
+## How to work in this repository
+
+1. **Inspect before editing**
+   First discover the real stack, commands, CI checks, and natural module boundaries from the repository itself.
+
+2. **Adapt to the existing repo**
+   If the repository already has equivalent modules, use them. Do not impose the suggested architecture when the repo already has a better-fitting structure.
+
+3. **Record what you discover**
+   Write repo-specific findings into `docs/spec/Documentation.md`.
+
+4. **Plan before complex changes**
+   Use `PLANS.md` and keep `plans/mvp_execplan.md` current.
+
+5. **Keep diffs tight**
+   Stay inside the current milestone. Do not opportunistically add adjacent features.
+
+6. **Verify continuously**
+   Run the best available format/typecheck/test/build/review commands after meaningful changes, not only at the end.
+
+7. **Review as a separate step**
+   Before declaring a milestone done, review the diff against `docs/review/code_review.md`.
+
+## Suggested responsibility map
+
+Map these responsibilities onto the real repo layout:
+
+- domain / schema / invariants
+- source ingest / compile pipeline
+- passport generation / redaction
+- gateway / visa / mount logic
+- review queue / diff / audit logic
+- thin UI
+- contract tests / fixtures
+
+If the repo is empty or near-empty, a reasonable default is:
+
+- `apps/web`
+- `apps/api`
+- `packages/domain`
+- `packages/compiler`
+- `packages/passport`
+- `packages/gateway`
+- `packages/review`
+- `tests/contracts`
+
+## Planning rules
+
+- Use a plan for any multi-step, ambiguous, or high-risk task.
+- Keep milestone acceptance criteria explicit.
+- If a validation fails, stop and fix before moving on.
+- If the repo contradicts the ideal architecture, write down the decision and why.
+- Plans are living documents, not static proposals.
+
+## Skills and delegation
+
+This repository includes repo-local skills under `.agents/skills`.
+
+Preferred usage:
+
+- use `$repo-recon` when you need to inventory the repo before coding
+- use `$evidence-trace-review` when changes touch compile/passport/gateway/review trust boundaries
+- use `$compiler-bench-loop` only after a fixed evaluator exists
+
+Subagents are optional and must be used intentionally. If you use them:
+
+- use at most one read-only exploration subagent for repo discovery or code search
+- use at most one review-oriented subagent for a second-pass critique
+- do not create a web of nested agents
+- do not use subagents to bypass the milestone boundary
+
+## Default surface and permissions
+
+Outside-AI default surface:
+
+- Passport manifest
+- active Focus Card
+- representative Topic Cards
+
+MVP scopes only:
+
+- `passport_read`
+- `topic_read`
+- `writeback_candidate`
+
+No default whole-workspace search for outside AI.
+
+Every mount session must record:
+
+- who accessed
+- when
+- which scope was granted
+- what was read
+- what candidates were written back
+
+## Review rules
+
+- Canonical knowledge changes must go through a review queue.
+- Review should be diff-first.
+- Rejection should be cheap and lossless.
+- Writeback candidates must preserve source session trace and evidence references when applicable.
+
+## Validation order
+
+When the repo supports these, validate in this order:
+
+1. formatting / static checks
+2. type checking
+3. unit tests
+4. contract tests / fixtures
+5. milestone-specific validation
+6. review against `docs/review/code_review.md`
+
+## Definition of done
+
+A milestone is done only when all of the following are true:
+
+- the scoped feature works end-to-end for that milestone
+- relevant checks pass
+- relevant tests pass
+- docs are updated
+- `plans/mvp_execplan.md` reflects reality
+- risks and assumptions are recorded
+- no speculative adjacent feature was added
+- the diff passes a trust-boundary review
+=======
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+This repository's canonical mission is to build a local-first, traceable AI personal knowledge passport system.
+
+## Working contract
+
+- Prefer small, reviewable PRs on `codex/*` branches.
+- Keep runtime behavior stable unless the change explicitly targets runtime behavior.
+- Use `npm run verify` as the baseline local verification step before PR.
+- Preserve source traceability and user-governed boundaries in product and docs changes.
+
+## Canonical guidance order
+
+When guidance conflicts, use this order:
+
+1. `AGENTS.md` (repo mission and agent workflow contract)
+2. `PLANS.md` (plan quality and execution requirements)
+3. `plans/mvp_execplan.md` (current execution baseline)
+4. Context/background docs such as `docs/project-blueprint.md`
+
+## Documentation expectations
+
+- Keep implementation-facing docs under `docs/spec`.
+- Keep research process and findings under `docs/research`.
+- Keep review standards and checklists under `docs/review`.
+- Keep codex/automation workflow docs under `docs/codex`.
+
+## Verification
+
+- Required verification block for PRs: `npm run verify`
+- CI mirror: `.github/workflows/ci.yml` runs `npm run ci:verify`.
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,177 @@
+# PLANS.md
+
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+This file defines how execution plans work in this repository.
+
+A plan is a **living, self-contained implementation document** that a coding agent can follow from repo discovery to validated delivery. The canonical project plan is `plans/mvp_execplan.md`.
+
+## When a plan is required
+
+A plan is required when the task is any of the following:
+
+- multi-step
+- ambiguous
+- high-risk
+- likely to touch multiple files or modules
+- likely to require architectural choices
+- likely to require custom validation
+- likely to exceed one short edit loop
+
+For a very small, local, low-risk patch, a separate plan is optional.
+
+## Principles
+
+- Treat the plan as the source of truth for milestone scope.
+- Keep the plan self-contained enough that a fresh session can resume from it.
+- Update the plan as facts change.
+- If repo reality conflicts with the plan, record the decision and revise the plan.
+- Milestones should be small enough to complete and validate in one focused pass.
+- Validation failures are stop signs, not “known issues to clean up later.”
+
+## Required sections for an execution plan
+
+Every substantial plan should contain:
+
+1. **Objective**
+   What success looks like in user/product terms.
+
+2. **Source documents**
+   Which files define the product intent, constraints, and review rules.
+
+3. **Repo inventory**
+   Discovered stack, commands, module boundaries, and constraints.
+
+4. **Milestones**
+   Ordered checkpoints with deliverables.
+
+5. **Acceptance criteria**
+   Concrete conditions that prove each milestone is done.
+
+6. **Validation**
+   Exact commands or procedures to run.
+
+7. **Risk register**
+   What could go wrong and how to mitigate it.
+
+8. **Decision log**
+   Architecture or scope decisions that avoid oscillation.
+
+9. **Status**
+   Current state of each milestone.
+
+## Writing milestones
+
+Good milestones are:
+
+- narrow
+- testable
+- low-ambiguity
+- compatible with existing repo structure
+- explicit about what is out of scope
+
+Bad milestones are:
+
+- “build everything”
+- “refactor as needed”
+- “improve architecture”
+- “set up all infra”
+- “make it production ready”
+
+## Standard execution loop
+
+For each milestone:
+
+1. Re-read the relevant source docs.
+2. Inventory the exact code to touch.
+3. State the intended diff.
+4. Make the smallest coherent change.
+5. Run validations.
+6. Repair failures immediately.
+7. Update docs and status.
+8. Review the diff before moving on.
+
+## Stop-and-fix rule
+
+If any required validation fails:
+
+- stop advancement
+- diagnose the failure
+- fix it or narrow the milestone
+- document what changed
+
+Do not stack multiple broken validations and “clean up later.”
+
+## Scope control rule
+
+Do not add adjacent features unless they are:
+
+- a strict prerequisite, and
+- small enough to explain in one paragraph in the decision log
+
+## Research-loop rule
+
+Benchmark-driven optimization loops are **disabled by default**.
+
+Only enable them when all of the following are true:
+
+- a fixed evaluator exists
+- fixtures are checked in
+- writable scope is narrow
+- guardrail metrics are defined
+- stop conditions are defined
+
+## Review rule
+
+Before marking a milestone done, review against `docs/review/code_review.md`.
+
+## Plan hygiene
+
+Keep plan updates concise but specific:
+
+- what changed
+- why it changed
+- what is complete
+- what remains blocked
+=======
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+This file defines plan requirements for this repository.
+
+## Plan requirements
+
+Every execution plan should:
+
+1. Start from observed repository state (no `TODO` / `UNKNOWN` placeholders for discoverable facts).
+2. Separate docs/process changes from runtime/API/schema changes.
+3. Include a verification section centered on `npm run verify`.
+4. Track status explicitly (`not started`, `in progress`, `blocked`, `done`).
+5. Link to concrete files and commands so another contributor can execute the plan without guesswork.
+
+## Plan lifecycle
+
+- Draft or update plans in `plans/`.
+- Keep one canonical active MVP plan at `plans/mvp_execplan.md`.
+- When reality changes (stack, paths, commands, CI), update the plan in the same PR if practical.
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs

--- a/README.md
+++ b/README.md
@@ -273,12 +273,23 @@ The current priority is not adding more abstract layers. It is tightening the pr
 
 For the full product-system framing, see [docs/project-blueprint.md](./docs/project-blueprint.md).
 
+## Contributor Control Docs
+
+For canonical contributor workflow and planning guidance, start here:
+
+- [AGENTS.md](./AGENTS.md)
+- [PLANS.md](./PLANS.md)
+- [plans/mvp_execplan.md](./plans/mvp_execplan.md)
+
 ## Contributing
 
 Contributions of code, documentation, tests, fixtures, and design ideas are welcome.
 
 Before contributing, please read:
 
+- [AGENTS.md](./AGENTS.md)
+- [PLANS.md](./PLANS.md)
+- [plans/mvp_execplan.md](./plans/mvp_execplan.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 - [SECURITY.md](./SECURITY.md)

--- a/docs/codex/followup_prompts.md
+++ b/docs/codex/followup_prompts.md
@@ -1,0 +1,116 @@
+# Follow-up Prompts for Codex
+
+## Prompt for M2 — Compile pipeline v0
+
+Read `AGENTS.md`, `PLANS.md`, `plans/mvp_execplan.md`, `docs/spec/Prompt.md`, `docs/spec/Borrowed_Patterns_and_Risks.md`, and `docs/review/code_review.md` first.
+
+Use plan mode if available.
+
+Implement **M2 only**.
+
+Goal:
+Build the source -> compile pipeline that generates evidence-backed knowledge artifacts and a Passport.
+
+Required behaviors:
+- preserve raw sources
+- generate knowledge nodes (`topic`, `project`, `method`, `question`)
+- extract evidence fragments
+- generate capability signals
+- generate mistake patterns
+- generate 3-5 representative Topic Cards / postcards
+- regenerate Passport including active Focus Card
+
+Constraints:
+- do not widen outside-AI access
+- do not implement mount/review UI yet
+- do not start research-loop optimization
+- keep cold start simple and inspectable
+
+Validation:
+- format / typecheck / tests
+- fixture or golden validation if available
+- review against `docs/review/code_review.md`
+
+---
+
+## Prompt for M3 — Gateway + Review + Audit
+
+Read the same control docs first.
+
+Use plan mode if available.
+
+Implement **M3 only**.
+
+Goal:
+Enable narrow outside-AI delivery with Passport-first access, Visa-gated deep reads, mount-session logging, writeback candidates, review queue support, and audit trail behavior.
+
+Constraints:
+- default outside-AI surface remains Passport + Focus Card + representative Topic Cards
+- no whole-workspace default search
+- no auto-merge writeback
+- keep permissions to `passport_read`, `topic_read`, `writeback_candidate`
+
+Validation:
+- contract tests for access control and writeback behavior
+- review against `docs/review/code_review.md`
+
+---
+
+## Prompt for M4 — Thin UI
+
+Read the same control docs first.
+
+Use plan mode if available.
+
+Implement **M4 only**.
+
+Goal:
+Create the thin operator UI for:
+- Dashboard
+- Inbox
+- Knowledge
+- Passport
+- Mount
+- Review
+
+Constraints:
+- do not create speculative pages for every internal object
+- keep user-facing objects simple
+- capability signals and mistake patterns can appear as sections, not primary products
+- trust/review surfaces must remain obvious
+
+Validation:
+- real frontend checks for the repo
+- manual smoke-test notes
+- review against `docs/review/code_review.md`
+
+---
+
+## Prompt for M5 — Bounded compiler optimization loop
+
+Read:
+- `AGENTS.md`
+- `PLANS.md`
+- `plans/mvp_execplan.md`
+- `docs/research/program.md`
+- `docs/research/eval_contract.md`
+- `docs/review/code_review.md`
+
+Only proceed if the evaluator already exists.
+
+Use `$compiler-bench-loop`.
+
+Task:
+Run one bounded optimization batch against the named compiler module.
+
+Constraints:
+- max 3 experiments
+- no fixture edits
+- no evaluator edits
+- no infinite loop
+- keep the commit only if guardrails pass and score improves
+
+Outputs:
+- structured result entries in local `results.tsv`
+- kept or discarded diff with explanation
+- review summary

--- a/docs/codex/initial_task.md
+++ b/docs/codex/initial_task.md
@@ -1,0 +1,71 @@
+Read these files first, in order:
+
+1. `AGENTS.md`
+2. `PLANS.md`
+3. `plans/mvp_execplan.md`
+4. `docs/spec/Prompt.md`
+5. `docs/spec/Borrowed_Patterns_and_Risks.md`
+6. `docs/review/code_review.md`
+
+Use plan mode if available.
+
+Task for this run:
+
+## Phase 1 — M0 only
+Do repo reconnaissance first.
+
+Requirements:
+- inspect the repository to discover the real stack, commands, CI, migrations, tests, and natural module boundaries
+- do not assume the suggested architecture if the repo already has equivalent modules
+- fill `docs/spec/Documentation.md`
+- update `plans/mvp_execplan.md` with discovered commands, stack, and insertion points
+- identify whether scaffolding is needed or whether the existing structure should be extended
+
+Constraints:
+- keep this phase read-heavy and edit-light
+- do not implement product code yet unless a tiny scaffold or doc fix is strictly required for M0
+
+Deliverables:
+- updated `docs/spec/Documentation.md`
+- updated `plans/mvp_execplan.md`
+- concise summary of repo inventory, recommended insertion points, and open blockers
+
+## Phase 2 — If and only if M0 is complete, do M1 only
+Implement the domain/schema milestone.
+
+Required entities:
+- workspace
+- source
+- knowledge_node
+- evidence_fragment
+- capability_signal
+- mistake_pattern
+- focus_card
+- postcard or topic_card representation
+- passport
+- visa_bundle
+- mount_session
+- review_candidate
+- audit_log
+
+Constraints:
+- keep permissions limited to `passport_read`, `topic_read`, `writeback_candidate`
+- preserve evidence traceability in the schema
+- do not implement mount/review/UI features beyond minimal domain/schema support
+- do not start the compile pipeline
+- do not start benchmark optimization work
+
+Required outputs:
+- domain models/types/entities
+- schema + migration(s)
+- realistic seed data for one sample workspace
+- tests for invariants and relations
+- updated docs and plan status
+
+Validation:
+- run the repo’s real format/typecheck/test/build commands if they exist
+- if commands do not exist, document that clearly instead of inventing fake success
+
+Before finishing:
+- review the diff against `docs/review/code_review.md`
+- summarize created files, commands run, test results, assumptions, and blockers

--- a/docs/project-blueprint.md
+++ b/docs/project-blueprint.md
@@ -1,5 +1,7 @@
 # Project Blueprint
 
+> Canonical implementation controls now live in `AGENTS.md`, `PLANS.md`, and `plans/mvp_execplan.md`. Treat this file as background product framing, not the primary execution guide.
+
 ## One-line Definition
 
 AI Personal Knowledge Passport System is an AI-mountable personal knowledge base: a local-first system for knowledge compilation, authorized projection, and governed AI use.
@@ -189,3 +191,13 @@ The repo already contains deep advanced layers. The present priority is product 
 4. Make passport the canonical AI entry surface
 
 If those layers mature, the system stops reading like a broad future-total platform and starts behaving like a concrete AI-readable personal knowledge base.
+
+## Canonical Implementation Guidance
+
+This blueprint is product/background context. For canonical implementation and execution guidance, use:
+
+- [`AGENTS.md`](../AGENTS.md)
+- [`PLANS.md`](../PLANS.md)
+- [`plans/mvp_execplan.md`](../plans/mvp_execplan.md)
+- [`docs/spec/Documentation.md`](./spec/Documentation.md)
+

--- a/docs/research/eval_contract.md
+++ b/docs/research/eval_contract.md
@@ -1,0 +1,116 @@
+# Evaluator Contract — Compiler / Passport Quality
+
+This contract defines how compiler and passport quality should be measured.
+
+## Why this exists
+
+A single scalar metric is too weak for this product.
+Compiler changes must improve usefulness **without** harming privacy, evidence traceability, or latency.
+
+## Fixture set
+
+A reasonable minimum benchmark set is 10 fixtures across representative source types, such as:
+
+1. markdown study note
+2. project README or design doc
+3. meeting summary
+4. PDF excerpt or extracted text
+5. research note
+6. reflection / learning log
+7. error/debugging log
+8. method/process document
+9. mixed-topic folder snapshot
+10. focus/goal note
+
+Each fixture should include:
+
+- raw source input
+- expected topic hints
+- must-keep evidence fragments
+- expected focus terms (if applicable)
+- forbidden leaks / redacted content expectations
+
+## Required evaluator outputs
+
+The evaluator should emit structured output with at least:
+
+- `evidence_coverage` — fraction of required claims or sections backed by expected evidence
+- `citation_precision` — fraction of included citations/evidence links that actually support the claim
+- `focus_alignment` — how well the output reflects the active Focus Card or current task
+- `passport_token_count` — approximate token size of the delivered Passport surface
+- `compile_seconds` — end-to-end runtime for the compile step under test
+- `unsafe_leak_count` — count of privacy or scope violations
+
+Optional helpful metrics:
+
+- `topic_recall`
+- `signal_quality`
+- `mistake_pattern_quality`
+- `review_pollution_risk`
+
+## Guardrails
+
+Minimum guardrails for a candidate to be promotable:
+
+- `unsafe_leak_count == 0`
+- `citation_precision >= baseline_citation_precision`
+- `focus_alignment >= baseline_focus_alignment - tolerance`
+- `passport_token_count <= baseline_token_count * 1.15`
+- `compile_seconds <= baseline_compile_seconds * 1.20`
+
+You may tighten these if the repo’s benchmark harness supports it.
+
+## Recommended composite score
+
+Only use a composite score after guardrails pass.
+
+Suggested weighted score:
+
+`score = 0.40 * evidence_coverage + 0.35 * citation_precision + 0.25 * focus_alignment`
+
+Token count and latency are treated as guardrails, not reward terms.
+
+## Promotion threshold
+
+A candidate is promotable only if:
+
+- guardrails pass, and
+- `score >= baseline_score + 0.01`
+
+Adjust the epsilon only if measurement noise clearly requires it.
+
+## Evaluator output shape (suggested)
+
+```json
+{
+  "run_id": "2026-04-05-a",
+  "scope": "packages/compiler/src/compile_passport.ts",
+  "score": 0.82,
+  "evidence_coverage": 0.84,
+  "citation_precision": 0.89,
+  "focus_alignment": 0.71,
+  "passport_token_count": 1340,
+  "compile_seconds": 2.8,
+  "unsafe_leak_count": 0,
+  "status": "keep",
+  "summary": "Improved evidence selection without increasing leaks."
+}
+```
+
+## Anti-gaming rules
+
+The evaluator should not reward:
+
+- shorter outputs that omit essential evidence
+- vague claims with no traceability
+- overconfident capability claims
+- hidden widening of access scope
+- silently dropping difficult sections
+
+## Manual fallback
+
+If an automated evaluator does not yet exist, do **not** start a research loop.
+Instead:
+
+- build the evaluator as a normal milestone,
+- or run a one-off manual comparison outside the bounded research protocol.

--- a/docs/research/program.md
+++ b/docs/research/program.md
@@ -1,0 +1,130 @@
+# Bounded Compiler Research Program
+
+This document defines the only allowed “autoresearch-like” loop for this repository.
+
+## Status
+
+**Disabled by default.**
+Do not start this loop unless the evaluator and fixtures already exist and the human explicitly asks for compiler optimization work.
+
+## Purpose
+
+Improve one narrow compiler or passport-generation module using fixed fixtures and guardrail metrics.
+
+This is **not** an open-ended autonomy loop.
+
+## Preconditions
+
+All of these must be true before starting:
+
+- `docs/research/eval_contract.md` exists and is implemented
+- fixed fixtures are checked in
+- golden expectations or structured expected outputs exist
+- writable scope can be narrowed to one module or file set
+- the human explicitly asks for an optimization run
+
+If any precondition is false, do normal milestone work instead.
+
+## Human-owned files
+
+Do not modify these during an optimization loop unless the human explicitly asks:
+
+- `AGENTS.md`
+- `PLANS.md`
+- `plans/mvp_execplan.md`
+- `docs/spec/Prompt.md`
+- `docs/spec/Borrowed_Patterns_and_Risks.md`
+- `docs/research/eval_contract.md`
+- fixtures and goldens
+
+## Read-only evaluation surface
+
+Do not modify during optimization:
+
+- evaluator code
+- benchmark fixtures
+- golden outputs
+- redaction/leakage rules
+- review policy docs
+
+## Writable scope
+
+The human or plan must name one narrow writable scope, for example:
+
+- `packages/compiler/src/compile_passport.ts`
+- `packages/compiler/src/postcard_builder.ts`
+- `apps/api/src/passport/serializer.ts`
+
+If writable scope is not explicitly named, do not start the loop.
+
+## Branching
+
+Use a dedicated branch such as:
+
+`research/passport-compiler/<tag>`
+
+If the repo prefers worktrees and they are already in use, a matching worktree is acceptable. Otherwise use a branch only.
+
+## Experiment budget
+
+Per optimization run:
+
+- maximum experiments: 3
+- maximum kept commits: 1 unless the human asks for a longer run
+- stop early if no meaningful improvement is found
+- do not continue indefinitely
+- do not ask “should I continue forever?”
+
+## Experiment protocol
+
+For each experiment:
+
+1. Re-read the evaluator contract.
+2. Re-state the writable scope.
+3. Make one coherent experimental change only.
+4. Commit the change locally.
+5. Run the evaluator.
+6. Record a structured result in `results.tsv`.
+7. Keep the commit only if the promotion rule passes.
+8. Otherwise reset to the previous kept commit.
+
+## Promotion rule
+
+A commit may be kept only if **all** of these hold:
+
+- `unsafe_leak_count == 0`
+- `citation_precision` does not regress
+- `focus_alignment` does not regress materially
+- token budget does not exceed the allowed guardrail
+- compile latency does not regress beyond the allowed guardrail
+- total score improves by the threshold defined in the evaluator contract
+
+If any guardrail fails, discard the commit.
+
+## Results ledger
+
+Use a tab-separated local ledger named `results.tsv`.
+
+Columns:
+
+`run_id	branch	commit	scope	evidence_coverage	citation_precision	focus_alignment	passport_token_count	compile_seconds	unsafe_leak_count	status	description`
+
+Do not commit `results.tsv` unless the human explicitly asks.
+
+## Logging discipline
+
+Do not feed raw terminal logs back into future prompts when a structured summary is available.
+
+Prefer:
+
+- evaluator JSON
+- summarized failure reason
+- last relevant stack trace excerpt only when needed
+
+## Hard prohibitions
+
+- no fixture edits
+- no evaluator edits
+- no widening writable scope mid-run without updating the plan
+- no infinite loops
+- no “improvements” that weaken evidence traceability or privacy

--- a/docs/review/code_review.md
+++ b/docs/review/code_review.md
@@ -1,0 +1,63 @@
+# Code Review Checklist
+
+Use this file when reviewing milestone diffs, ideally with `/review` or an explicit self-review pass.
+
+## 1. Scope discipline
+
+- Does the diff stay within the named milestone?
+- Did the change introduce speculative adjacent features?
+- If a prerequisite change expanded scope, is it explained in the plan/decision log?
+
+## 2. Product clarity
+
+- Does the change reinforce the product’s narrow value: helping AI understand the user faster?
+- Did the diff accidentally turn the product into a generic notes/wiki system?
+- Does the UI keep P0 user-facing objects simple (Passport, Focus Card, Topic Card)?
+
+## 3. Trust boundary
+
+- Is outside-AI default access still narrow?
+- Is the default surface still Passport + Focus Card + representative Topic Cards?
+- Is deep access still Visa-gated?
+- Is there any new path that can auto-merge outside-AI output into canonical knowledge? If yes, reject.
+
+## 4. Evidence traceability
+
+- Can high-level claims or summaries trace back to evidence fragments and sources?
+- Did any new artifact lose provenance?
+- Are tests or contracts covering evidence linkage where appropriate?
+
+## 5. Capability overclaim
+
+- Did any change introduce hard capability scoring or unjustified confidence?
+- Are “capability signals” still framed as evidence-backed observations and gaps?
+
+## 6. Privacy and leakage
+
+- Could the diff widen access to raw sources or the whole workspace unintentionally?
+- Are redaction, scope, or leakage rules weakened?
+- Are logs/audit records appropriate without exposing unnecessary sensitive content?
+
+## 7. Review and auditability
+
+- Are writebacks still candidates, not canonical merges?
+- Does the review path preserve source session trace?
+- Are revoke/expiry/audit paths preserved or improved?
+
+## 8. Technical quality
+
+- Are the changed files the right insertion points for this repo?
+- Are validations documented and run?
+- Are tests updated or added?
+- Are explicit errors preferred over silent fallbacks?
+
+## 9. Final verdict rubric
+
+A milestone should not be marked done if any of the following are true:
+
+- scope boundary broken
+- trust boundary weakened
+- evidence traceability regressed
+- privacy/safety guardrails regressed
+- validation incomplete
+- docs/status not updated

--- a/docs/spec/Borrowed_Patterns_and_Risks.md
+++ b/docs/spec/Borrowed_Patterns_and_Risks.md
@@ -1,0 +1,208 @@
+# Borrowed Patterns and Risks
+
+This file explains **what to borrow**, **what not to copy**, and **which weaknesses to guard against**.
+
+## Why this file exists
+
+The project draws inspiration from several strong patterns:
+
+- compiled knowledge systems
+- bounded experiment loops
+- agentic coding runtimes
+
+Those patterns are useful, but each also carries failure modes. This file prevents uncritical copying.
+
+---
+
+## A. From “LLM Wiki”-style compiled knowledge systems
+
+### Good patterns to adopt
+
+1. **Immutable raw source layer**
+   Keep original documents as the provenance source of truth.
+
+2. **Compiled middle layer**
+   Build reusable artifacts that accumulate value over time instead of re-deriving everything from raw files on every query.
+
+3. **Schema as an agent contract**
+   Use repo docs to tell the agent how to ingest, structure, answer, and maintain the system.
+
+4. **Index and log discipline**
+   Maintain a navigable catalog and a chronological ledger.
+
+5. **Lint / health-check mindset**
+   Periodically check for contradictions, stale claims, orphaned topics, and missing links.
+
+### Weaknesses and risks
+
+1. **Wiki sprawl**
+   A persistent wiki can explode into too many pages, weak structure, and inconsistent quality.
+
+2. **Markdown drift**
+   Free-form page editing can erode schema discipline over time.
+
+3. **Weak permissions**
+   A wiki pattern is usually optimized for synthesis, not object-level access control or scoped delivery.
+
+4. **Poor review boundaries**
+   It is easy for generated summaries to become canonical without enough scrutiny.
+
+5. **Search-first temptation**
+   Over time, teams may add broad search and accidentally expose more than the safe default surface.
+
+### Countermeasures in this repo
+
+- user-facing P0 is Passport + Focus Card + Topic Cards, not “the wiki”
+- evidence links are first-class
+- outside AI gets a narrow surface first
+- all outside-AI outputs become candidates, not canonical truth
+- review and audit are mandatory, not optional
+
+---
+
+## B. From “autoresearch”-style bounded experiment loops
+
+### Good patterns to adopt
+
+1. **Human edits the rules; agent edits the implementation**
+   Keep spec/eval files human-owned and narrow the agent’s writable scope.
+
+2. **Fixed evaluator**
+   Compare experiments under the same benchmark and budget.
+
+3. **Result ledger**
+   Record experiments in a structured, comparable format.
+
+4. **Keep/discard discipline**
+   Improvement should be measured, not merely narrated.
+
+5. **Branch isolation**
+   Experiments should not pollute the main line.
+
+### Weaknesses and risks
+
+1. **Infinite autonomy**
+   Unbounded loops can waste money, time, and attention.
+
+2. **Single-metric gaming**
+   A scalar objective can reward harmful regressions elsewhere.
+
+3. **Compute burn**
+   Frequent experiment loops can become expensive quickly.
+
+4. **Branch sprawl**
+   Too many experiment branches become confusing.
+
+5. **Benchmark overfit**
+   The agent can improve the benchmark while making real outputs worse.
+
+6. **Log overexposure**
+   Feeding raw logs back into the agent can create noisy or unsafe optimization behavior.
+
+### Countermeasures in this repo
+
+- research loops are **disabled by default**
+- bounded loops require a fixed evaluator and narrow writable scope
+- use multiple metrics and guardrails, not one scalar score
+- stop after a limited experiment budget
+- summarize results structurally instead of recycling raw logs
+- do not edit evaluator or fixtures during optimization
+
+---
+
+## C. From Claude Code-style agent runtimes
+
+### Good patterns to borrow conceptually
+
+1. **Plan vs execution separation**
+   Use a read-first planning phase before code changes.
+
+2. **Role separation**
+   Exploration, implementation, and review are different jobs.
+
+3. **Skills for reusable workflows**
+   Package recurring tasks into narrow, reusable instructions.
+
+4. **Isolation for risky work**
+   Use feature branches or worktrees when parallel or risky experimentation justifies them.
+
+5. **Long-session discipline**
+   Persist learnings in docs and ledgers, not only in chat state.
+
+### Weaknesses and risks
+
+1. **Runtime envy**
+   It is easy to copy the shape of a mature agent platform instead of solving the actual product problem.
+
+2. **Feature sprawl**
+   Hooks, subagents, worktrees, memory, plugins, and permissions can become an infrastructure project of their own.
+
+3. **Repo mismatch**
+   A runtime-heavy design may not fit the actual repository or product stage.
+
+4. **False confidence**
+   More automation can mask missing tests, weak specs, or poor product clarity.
+
+5. **Proprietary assumption leak**
+   Some runtime features may not exist in Codex or in this repo and should not be assumed.
+
+### Countermeasures in this repo
+
+- emulate the useful discipline, not the entire runtime
+- use AGENTS.md, PLANS.md, skills, review files, and validation scripts as portable controls
+- keep subagent use explicit and sparse
+- prefer feature branches first; use worktrees only when clearly justified
+- keep the product loop in focus
+
+---
+
+## D. From the original AI Passport PRD itself
+
+### Strengths to preserve
+
+- sharp pain: repeated background explanation across AI systems
+- evidence-backed capability signals instead of hard capability claims
+- explicit Focus Card / current goal layer
+- postcard/passport/visa model for controlled AI understanding
+- read-only-first outside AI access
+- review-gated writeback
+- auditability and revocation
+- cold-start priority on 3-5 high-value cards
+
+### Weaknesses to guard against
+
+1. **Concept overload**
+   Too many metaphors and top-level nouns can confuse users.
+
+2. **Future-platform drift**
+   The product can start sounding like a grand protocol or operating system instead of a useful tool.
+
+3. **Cold-start heaviness**
+   Trying to compile everything immediately makes the first experience slow and empty.
+
+4. **Capability overreach**
+   Overinterpreting notes/projects as true ability can mislead both user and AI.
+
+5. **Permission complexity**
+   Excess policy depth early on can reduce trust.
+
+### Countermeasures in this repo
+
+- P0 keeps only three user-facing objects
+- P0 keeps only three access scopes
+- cold start focuses on 3-5 representative cards
+- the product story stays narrow: help AI understand the user faster
+- protocol/export is treated as an output surface, not the main value
+
+---
+
+## E. Summary operating doctrine
+
+When there is tension between inspiration and practicality, choose:
+
+- compiled artifacts over repeated raw retrieval
+- bounded loops over open-ended autonomy
+- reviewability over cleverness
+- explicit scope over silent power
+- evidence over confident abstraction
+- a small, clear MVP over a grand runtime fantasy

--- a/docs/spec/Documentation.md
+++ b/docs/spec/Documentation.md
@@ -1,0 +1,176 @@
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+# Repository Documentation / Working Notes
+
+This file is updated as the repository is explored and changed.
+
+## 1. Repo inventory
+
+### 1.1 Root layout
+- `apps/web`: Next.js web app, route handlers, worker scripts, server services, and tests
+- `packages/shared`: shared Zod schemas and TypeScript types consumed by the app
+- `data`: default local runtime storage for SQLite, objects, exports, and backups
+- `docs`: product and contributor documentation
+- `.github`: CI workflow, PR template, and issue templates
+- `.agents/skills`: repo-local skills for recurring contributor workflows
+
+### 1.2 Stack
+- package manager: npm workspaces
+- languages: TypeScript, React, SQL/SQLite
+- frontend stack: Next.js 16 App Router, React 19, Tailwind CSS 4
+- backend/service stack: Next.js route handlers plus `apps/web/src/server/services/*`
+- database/persistence: SQLite via `better-sqlite3` + Drizzle ORM; local filesystem object storage under `data/`
+- test runner(s): Vitest
+
+### 1.3 Canonical commands
+- install: `npm install`
+- dev: `npm run dev:all`
+- format: no dedicated formatter script exists today
+- lint: no dedicated lint script exists today
+- typecheck: `npm run typecheck`
+- test: `npm run test`
+- build: `npm run build`
+- db migrate: no standalone migration command; schema creation and incremental upgrades live in `apps/web/src/server/db/init.ts`
+- db seed: `npm run demo:seed`
+
+### 1.4 CI / automation
+- GitHub Actions workflow: `.github/workflows/ci.yml`
+- triggers: pushes to `main` and `codex/**`, plus all pull requests
+- steps: checkout, setup Node 25 with npm cache, `npm ci`, `npm run ci:verify`
+- PR template expects a short summary plus explicit checkboxes for `npm run typecheck`, `npm run test`, and `npm run build`
+
+## 2. Architecture map
+
+### 2.1 Existing modules
+- domain and persistence: `apps/web/src/server/db/schema.ts` and `apps/web/src/server/db/init.ts`
+- shared contracts: `packages/shared/src/index.ts`
+- ingest and compile: `apps/web/src/server/services/sources.ts`, `parsers.ts`, `compiler.ts`
+- passport and context objects: `passports.ts`, `postcards.ts`, `signals.ts`, `focus-cards.ts`, `workspaces.ts`
+- gateway and access control: `visas.ts`, `grants.ts`, `policies.ts`, `privacy.ts`, route handlers under `apps/web/src/app/api/*`, and public mount routes under `apps/web/src/app/v/[token]`
+- review, audit, and downstream governed flows: `audit.ts`, `outputs.ts`, `exports.ts`, `agent-packs.ts`, `avatars.ts`, `avatar-live-sessions.ts`
+- UI: `apps/web/src/app/*` pages and `apps/web/src/components/*`
+- tests: `apps/web/src/server/tests/*`
+
+### 2.2 Best insertion points for MVP responsibilities
+- domain / schema: `apps/web/src/server/db/schema.ts` plus shared types in `packages/shared/src/index.ts`
+- compile pipeline: `apps/web/src/server/services/compiler.ts`, `parsers.ts`, and `sources.ts`
+- passport generation: `apps/web/src/server/services/passports.ts`, `postcards.ts`, `signals.ts`, and `focus-cards.ts`
+- gateway / access control: `apps/web/src/server/services/visas.ts`, `grants.ts`, `policies.ts`, `privacy.ts`, and related route handlers
+- review queue / audit: `apps/web/src/server/services/audit.ts`, `outputs.ts`, `visas.ts`, and the `/review` surface in `apps/web/src/app/review`
+- UI pages: `apps/web/src/app/dashboard`, `inbox`, `knowledge`, `passport`, `review`, `visas`, and related components
+- tests / fixtures: `apps/web/src/server/tests`; no dedicated evaluator or fixture directory is checked in yet
+
+## 3. Product implementation notes
+
+### 3.1 P0 user-facing objects
+- Passport
+- Focus Card
+- Topic Card
+
+### 3.2 Internal objects
+- Existing schema already models workspaces, sources, source fragments, claims/wiki nodes, postcards, passport snapshots, capability signals, mistake patterns, focus cards, visa bundles, visa access logs, visa feedback queue, agent-pack snapshots, avatar profiles/sessions, export packages, object policies, research sessions, outputs, and citations.
+
+### 3.3 Open questions
+- Should `Topic Card` be a renamed/refined presentation of the current `postcards` model, or a distinct object with separate persistence?
+- Should `review_candidate` extend the existing `visa_feedback_queue` / `outputs` path, or become a new canonical table when M3 begins?
+- Once fixture-driven compile work starts, should dedicated fixtures live under `apps/web/src/server/tests/fixtures` or in a new top-level test area?
+
+## 4. Decisions
+
+> Add concise decision notes here as the repo evolves.
+
+- Extend the existing `apps/web` and `packages/shared` structure instead of introducing new top-level apps/packages for MVP work.
+- Treat `apps/web/src/app/api/*` plus `apps/web/src/server/services/*` as the canonical API/service layer.
+- Treat `apps/web/src/server/db/init.ts` as the current migration/upgrade mechanism until a dedicated migration workflow is justified.
+- Use `npm run verify` as the canonical validation gate for contributor work.
+
+## 5. Milestone progress
+
+### M0
+- status: completed in the control-doc alignment PR
+
+### M1
+- status: not started
+
+### M2
+- status: not started
+
+### M3
+- status: not started
+
+### M4
+- status: not started
+
+### M5
+- status: blocked pending evaluator + fixtures
+
+## 6. Risks / blockers
+
+- No dedicated formatter or lint command exists yet, so plans and PRs should not claim those validations until they are added.
+- No fixed evaluator or checked-in compile fixture harness exists yet, so bounded research-loop work remains blocked.
+- The current app already exposes more internal surfaces than the narrowed P0 framing, so future milestones need to tighten presentation without destabilizing existing functionality.
+=======
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+# Documentation Spec Baseline
+
+This document captures the current repository implementation baseline and should be treated as the canonical quick inventory for contributors.
+
+## Repository topology
+
+- Monorepo managed by npm workspaces at root `package.json`:
+  - `apps/*`
+  - `packages/*`
+- Current workspace packages:
+  - `apps/web` (Next.js application package)
+  - `packages/shared` (shared types/schemas/constants)
+
+## Technology baseline
+
+- Next.js: `^16.2.2`
+- React / React DOM: `^19.1.0`
+- TypeScript (root dev dependency)
+- SQLite runtime via `better-sqlite3`
+- ORM/query layer via `drizzle-orm`
+- Validation/type schema surface includes `zod`
+
+## App structure
+
+- Primary app package: `apps/web`
+- Web routes and API handlers use the App Router in `apps/web/src/app`
+- Server services live in `apps/web/src/server/services`
+- DB schema/client/init live in `apps/web/src/server/db`
+- Shared package entrypoint: `packages/shared/src/index.ts`
+
+## Quality and CI baseline
+
+- Test runner: Vitest (`apps/web` script: `vitest run`)
+- Root verification command: `npm run verify`
+  - Runs typecheck
+  - Runs tests
+  - Runs production build
+- CI workflow: `.github/workflows/ci.yml`
+  - Runs on pushes to `main` and `codex/**`, plus pull requests
+  - Executes `npm ci` then `npm run ci:verify`
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs

--- a/docs/spec/Prompt.md
+++ b/docs/spec/Prompt.md
@@ -1,0 +1,301 @@
+# Product Prompt / Product Spec — AI知识护照盘
+
+## One-sentence positioning
+
+**把用户的资料、项目、误区和当前目标，编译成任何 AI 都能快速读懂的个人护照。**
+
+## The first pain to solve
+
+Users repeatedly have to re-explain themselves when they change:
+
+- model
+- task
+- context
+- project
+- learning phase
+
+This MVP exists to reduce that repetition.
+
+## Core product claim
+
+Outside AI should become faster and more accurate at helping the user **because it can read a compact, evidence-backed, goal-aware Passport first**, not because it gets unrestricted access to the whole workspace.
+
+## Target user
+
+P0 users are high-frequency AI collaborators who already accumulate meaningful materials, such as:
+
+- students
+- researchers
+- developers
+- creators
+- consultants
+- knowledge workers
+- freelancers
+
+Shared traits:
+
+- they switch between multiple AI systems
+- they have scattered notes/files/projects
+- they dislike repeating background context
+- they want better-calibrated help
+- they want valuable AI outputs to compound over time
+
+## Non-goals
+
+This product does **not** try to be, in MVP:
+
+- a generic cloud notes app
+- a social knowledge network
+- an enterprise team knowledge platform
+- a model training system
+- an autonomous agent swarm
+- a “give me a skill score” product
+- a protocol-first platform with weak actual utility
+
+## Product principles
+
+1. **Passport first**
+   Outside AI starts with a Passport manifest.
+
+2. **Postcard first**
+   Topic cards / postcards summarize high-value context before deep reads.
+
+3. **Read-only first**
+   Outside AI does not mutate canonical knowledge by default.
+
+4. **Evidence-backed**
+   High-level claims should trace to evidence fragments and sources.
+
+5. **Goal-aware**
+   The current Focus Card is essential. The system must express what the user is solving now.
+
+6. **Capability signals, not scores**
+   Use evidence-backed signs of practice and gaps, not hard ratings.
+
+7. **Local-first with controlled delivery**
+   Core knowledge remains user-controlled; delivery to outside AI is scoped and revocable.
+
+8. **Model-agnostic**
+   The system should not depend on one AI vendor.
+
+## User-facing objects in P0
+
+Keep the user mental model simple.
+
+### 1) Passport
+Top-level entry point for outside AI. Includes:
+
+- user summary
+- theme/topic map
+- active Focus Card
+- representative Topic Cards
+- selected capability signals
+- redaction-aware machine manifest
+
+### 2) Focus Card
+What the user is trying to solve **now**. Includes:
+
+- current goal
+- active problem
+- time window
+- priority
+- success criteria
+- related topics
+
+### 3) Topic Card
+A compact representation of one topic. Includes:
+
+- what the user appears to know
+- what they have done
+- recurring gaps or confusion
+- active questions
+- suggested next step
+- linked evidence
+
+## Internal objects
+
+Internally, the system may use:
+
+- workspace
+- source
+- knowledge_node
+- evidence_fragment
+- capability_signal
+- mistake_pattern
+- postcard
+- passport
+- visa_bundle
+- mount_session
+- review_candidate
+- audit_log
+
+Internal richness is allowed.
+User-facing complexity is not.
+
+## Architectural layers
+
+### Source layer
+Stores raw imported materials.
+
+### Compile layer
+Transforms sources into:
+
+- knowledge nodes
+- evidence fragments
+- capability signals
+- mistake patterns
+- topic cards / postcards
+
+### Passport layer
+Generates the Passport and machine-readable manifest.
+
+### Mount layer
+Delivers the narrow default surface and enforces Visa-based deep access.
+
+### Review & governance layer
+Handles review queue, audit log, revoke/expiry, and recovery/export.
+
+## Canonical flows
+
+### 1. Import and compile
+source import
+-> inbox
+-> parse / retain raw source
+-> generate knowledge nodes
+-> extract evidence fragments
+-> generate capability signals and mistake patterns
+-> update or propose Topic Cards
+-> regenerate Passport
+
+### 2. Mount and assist
+outside AI connects
+-> reads Passport manifest
+-> reads Focus Card + representative Topic Cards
+-> optionally requests deeper Topic/Card scope via Visa
+-> produces help for the user
+
+### 3. Writeback and review
+outside AI produces summary/outline/questions/next steps
+-> create writeback candidate
+-> enter review queue
+-> user accepts / edits then accepts / rejects
+-> accepted content merges into canonical knowledge with trace
+
+## P0 scope
+
+P0 includes:
+
+- multi-source import
+- source preservation
+- basic compile pipeline
+- capability signal extraction v0
+- mistake pattern extraction v0
+- Focus Card
+- Topic Cards / postcards
+- Passport generation
+- read-only-first mount
+- simple Visa control
+- mount session logs
+- writeback candidate queue
+- audit logs
+- local export/backup path if practical in the repo
+
+P0 excludes:
+
+- autonomous research as a product surface
+- cross-user knowledge sharing
+- enterprise permission complexity
+- automatic execution in external systems
+- full graph exploration UX
+- always-on connectors sprawl
+- automatic writeback merge
+
+## Minimal permission model
+
+Only three scopes are required in MVP:
+
+- `passport_read`
+- `topic_read`
+- `writeback_candidate`
+
+Anything beyond that should be treated as out of scope.
+
+## Default delivery surface
+
+Outside AI should **not** start with:
+
+- whole-workspace search
+- arbitrary raw source reads
+- all knowledge nodes
+- unrestricted compiled graph traversal
+
+Outside AI **should** start with:
+
+- Passport manifest
+- active Focus Card
+- 3-5 representative Topic Cards
+
+## Cold-start policy
+
+Cold start is a major risk.
+
+The first week goal is **not** to model the whole person.
+
+The first week goal is:
+
+- import a few meaningful sources
+- compile enough evidence-backed structure
+- generate 3-5 high-value representative Topic Cards
+- generate the first useful Passport
+
+If the repo or UX choices make cold start feel heavy, prefer simplification.
+
+## UI priorities for P0
+
+P0 page set:
+
+- Dashboard
+- Inbox
+- Knowledge
+- Passport
+- Mount
+- Review
+
+Avoid over-segmenting the UI into too many concept pages.
+Signals and mistake patterns can live as sections inside Knowledge or cards.
+
+## Minimal API/gateway surface (suggested)
+
+If this repo needs an HTTP surface, a minimal gateway is enough:
+
+- `GET /passport/{id}/manifest`
+- `GET /cards/{id}`
+- `POST /visas`
+- `POST /mount-sessions`
+- `POST /writeback-candidates`
+
+This is guidance, not a mandatory route shape.
+
+## Success metrics
+
+### North star
+After reading the Passport, outside AI gives more useful, better-calibrated help with less repeated user explanation.
+
+### Supporting metrics
+- reduction in repeated background explanation
+- first-response match quality
+- evidence coverage for high-level claims
+- Passport usefulness rating
+- cold-start completion success
+- writeback candidate acceptance rate
+- zero unsafe default data leaks
+
+## Design discipline
+
+When in doubt:
+
+- choose clarity over abstraction
+- choose reviewability over automation
+- choose a smaller surface over a cleverer framework
+- choose evidence-backed signals over confident guesses
+- choose one good default path over many metaphors

--- a/plans/mvp_execplan.md
+++ b/plans/mvp_execplan.md
@@ -1,0 +1,421 @@
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+# MVP Execution Plan — AI知识护照盘 / AI Passport
+
+## Objective
+
+Ship an MVP that proves one thing:
+
+**Outside AI can understand the user faster and more accurately after reading a Passport than in an empty conversation, without being given full default access to the user’s knowledge base.**
+
+## Source documents
+
+Use these as the source of truth:
+
+- `AGENTS.md`
+- `PLANS.md`
+- `docs/spec/Prompt.md`
+- `docs/spec/Borrowed_Patterns_and_Risks.md`
+- `docs/review/code_review.md`
+- `docs/research/eval_contract.md` (only when the evaluator exists)
+- `docs/research/program.md` (only for bounded benchmark loops)
+
+## Current repo inventory
+
+### Stack
+- package manager: npm workspaces
+- language(s): TypeScript, React, SQL/SQLite
+- app/runtime layout: Next.js App Router app in `apps/web`, shared types/schemas in `packages/shared`, local data under `data/`
+- database/persistence: SQLite via `better-sqlite3` + Drizzle ORM, plus local object/file storage
+- test runner(s): Vitest
+
+### Commands
+- install: `npm install`
+- format: no dedicated formatter script exists today
+- lint: no dedicated lint script exists today
+- typecheck: `npm run typecheck`
+- test: `npm run test`
+- build: `npm run build`
+- migration/seed: no standalone migration CLI; schema bootstrap and incremental upgrades live in `apps/web/src/server/db/init.ts`; demo seed is `npm run demo:seed`
+
+### Architecture notes
+- canonical API layer: Next.js route handlers under `apps/web/src/app/api/*` plus public mount routes under `apps/web/src/app/v/[token]`
+- canonical domain/model layer: `apps/web/src/server/db/schema.ts`, `apps/web/src/server/db/init.ts`, and shared schemas/types in `packages/shared/src/index.ts`
+- canonical UI layer: `apps/web/src/app/*` and `apps/web/src/components/*`
+- canonical test/fixture location: `apps/web/src/server/tests`; no dedicated evaluator/fixture harness is checked in yet
+
+## Milestones
+
+### M0 — Repo reconnaissance and control-doc alignment
+
+Goal:
+- discover the actual repo structure, commands, conventions, and insertion points
+- align the control docs to repo reality before product implementation
+
+Deliverables:
+- fill in `docs/spec/Documentation.md`
+- update this plan with discovered commands and module map
+- identify the natural home for domain/compiler/passport/gateway/review responsibilities
+- decide whether scaffolding is needed or whether existing modules should be extended
+
+Acceptance criteria:
+- repo commands are documented
+- module map is documented
+- open unknowns are reduced to specific questions or assumptions
+- no product code changed unless a tiny doc/scaffold change was strictly necessary
+
+Validation:
+- run the safest read-only discovery commands available
+- if docs-only changes were made, no additional validation is required beyond confirming file integrity
+
+Status: COMPLETED in the control-doc bundle PR. Repo inventory and insertion points are documented, and no runtime behavior was changed.
+
+---
+
+### M1 — Domain layer, schema, and seed data
+
+Goal:
+- create or extend the canonical domain and persistence model for the MVP
+
+Required entities:
+- workspace
+- source
+- knowledge_node
+- evidence_fragment
+- capability_signal
+- mistake_pattern
+- focus_card
+- postcard or topic_card representation
+- passport
+- visa_bundle
+- mount_session
+- review_candidate
+- audit_log
+
+Deliverables:
+- domain types/models/entities
+- persistence schema and migration(s)
+- seed data for one realistic sample workspace
+- tests for key invariants and relations
+- documentation updates
+
+Acceptance criteria:
+- every high-level artifact can trace to evidence/source
+- permission model is restricted to `passport_read`, `topic_read`, `writeback_candidate`
+- writeback objects are candidates, not canonical merges
+- schema supports revocation, auditability, and versioning where needed
+
+Validation:
+- format
+- typecheck
+- tests
+- migration and seed validation if applicable
+
+Status: NOT STARTED
+
+---
+
+### M2 — Compile pipeline v0
+
+Goal:
+- compile imported sources into reusable, evidence-backed artifacts
+
+Required pipeline outputs:
+- knowledge nodes (`topic`, `project`, `method`, `question`)
+- evidence fragments
+- capability signals
+- mistake patterns
+- representative topic cards / postcards
+- passport manifest regeneration
+
+Deliverables:
+- ingest-to-compile pipeline
+- source preservation and provenance links
+- fixture-driven tests using representative inputs
+- documentation updates
+
+Acceptance criteria:
+- raw sources remain preserved
+- high-level artifacts have evidence links
+- cold start can produce 3-5 representative cards
+- active Focus Card is included in Passport output
+- compile outputs are inspectable and reviewable
+
+Validation:
+- format
+- typecheck
+- tests
+- fixture/golden validation
+- benchmark harness only if it already exists
+
+Status: NOT STARTED
+
+---
+
+### M3 — Gateway, mount, review, and audit
+
+Goal:
+- allow safe outside-AI access without giving away the whole workspace
+
+Required behaviors:
+- default surface is Passport + Focus Card + representative cards
+- deeper access requires a Visa Bundle
+- sessions are logged
+- outside AI can only submit writeback candidates
+- review queue is diff-first
+- audit trail records read/write/revoke/review actions
+
+Deliverables:
+- API/service layer for passport read
+- visa creation and enforcement
+- mount session recording
+- writeback candidate submission
+- review queue and decision actions
+- audit log plumbing
+- contract tests
+
+Acceptance criteria:
+- no whole-workspace default access
+- no auto-merge from outside AI
+- session trace is preserved
+- revoke and expiry paths exist
+
+Validation:
+- format
+- typecheck
+- tests
+- contract tests for access control and writeback behavior
+
+Status: NOT STARTED
+
+---
+
+### M4 — Thin operator UI
+
+Goal:
+- expose only the minimum surfaces needed to operate the MVP
+
+P0 pages:
+- Dashboard
+- Inbox
+- Knowledge
+- Passport
+- Mount
+- Review
+
+Design guidance:
+- user-facing objects stay limited to Passport, Focus Card, Topic Cards
+- capability signals and mistake patterns may appear as sections, not separate top-level products
+- default UI should reinforce trust and review, not abstraction sprawl
+
+Deliverables:
+- thin UI scaffolding or pages in the repo’s real frontend
+- minimal flows for viewing Passport, inspecting evidence, managing mount sessions, and reviewing writeback candidates
+
+Acceptance criteria:
+- no speculative “future platform” UI
+- no needlessly separate nav for Signals/Postcards if the repo is starting from scratch
+- review and audit surfaces are visible and understandable
+
+Validation:
+- format
+- typecheck
+- tests where the frontend stack supports them
+- manual smoke test notes
+
+Status: NOT STARTED
+
+---
+
+### M5 — Bounded compiler optimization loop (optional, later)
+
+Goal:
+- improve compiler/passport quality with a fixed evaluator and strict guardrails
+
+Preconditions:
+- M2 is complete
+- evaluator exists
+- fixtures are checked in
+- guardrail metrics are defined
+- writable scope can be narrowed to one module
+
+Deliverables:
+- evaluator wiring
+- local `results.tsv` usage
+- one bounded experiment batch if explicitly requested
+
+Acceptance criteria:
+- no infinite autonomy
+- no fixture edits
+- no evaluator edits during optimization
+- score improvements respect safety/token/latency guardrails
+
+Validation:
+- evaluator output
+- results ledger entry
+- review of kept diff
+
+Status: BLOCKED until M2 + evaluator exist
+
+## Out of scope for MVP
+
+- multi-agent autonomous research as a product feature
+- public sharing/social graph
+- enterprise RBAC matrix
+- broad connector ecosystem
+- model training or fine-tuning
+- automatic writeback merge
+- full-text outside-AI search over all private knowledge by default
+
+## Risk register
+
+1. **Concept overload**
+   Too many metaphors or object types can make the product unreadable.
+   Mitigation: Passport + Focus Card + Topic Card are the only top-level user objects in P0.
+
+2. **Compile hallucination**
+   High-level summaries may distort the source.
+   Mitigation: evidence traceability, reviewability, and fixture tests.
+
+3. **Capability overclaim**
+   Notes/projects do not equal true skill.
+   Mitigation: capability signals only, never hard scores.
+
+4. **Permission creep**
+   “Temporary” shortcuts can widen access beyond the intended surface.
+   Mitigation: explicit three-scope access model and contract tests.
+
+5. **Benchmark gaming**
+   Optimizing only one scalar score can produce worse real outputs.
+   Mitigation: multi-metric evaluator with guardrails.
+
+6. **Repo mismatch**
+   Forcing a prewritten architecture onto the real repo can cause churn.
+   Mitigation: M0 reconnaissance first, adapt before scaffolding.
+
+## Decision log
+
+> Update as decisions are made.
+
+- Extend the existing `apps/web` and `packages/shared` modules instead of inventing new top-level apps/packages for the MVP.
+- Treat `apps/web/src/app/api/*` plus `apps/web/src/server/services/*` as the canonical API/service layer.
+- Treat `apps/web/src/server/db/init.ts` as the current migration/upgrade mechanism until a dedicated migration workflow is justified.
+- Use `npm run verify` as the canonical contributor validation gate for this repo.
+
+## Status summary
+
+- M0: completed
+- M1: not started
+- M2: not started
+- M3: not started
+- M4: not started
+- M5: blocked
+
+## Notes for the current run
+
+This control-doc bundle PR is intentionally docs/process-only:
+
+- imported the canonical control docs and repo-local skills
+- aligned M0 inventory content with the actual monorepo
+- left runtime behavior unchanged
+
+Default starting instruction unless the human says otherwise:
+
+- do **M1 only** next
+- do **not** start M2+ without explicit instruction
+=======
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+# MVP Execution Plan
+
+Status: in progress
+Last updated: 2026-04-05
+
+## M0 — Repository inventory baseline
+
+### Monorepo/workspaces
+
+- Root `package.json` defines npm workspaces:
+  - `apps/*`
+  - `packages/*`
+- Active packages:
+  - `apps/web` (`@ai-knowledge-passport/web`)
+  - `packages/shared` (`@ai-knowledge-passport/shared`)
+
+### Stack and runtime
+
+- App framework: Next.js `^16.2.2` (App Router)
+- UI: React `^19.1.0`, TypeScript
+- Persistence: SQLite via `better-sqlite3` + Drizzle ORM
+- Testing: Vitest (`vitest run` in `apps/web`)
+- CI verification: `.github/workflows/ci.yml` installs deps and runs `npm run ci:verify` (`npm run verify`)
+
+### Core repository paths
+
+- Web app and server logic: `apps/web/`
+- Shared schemas/types: `packages/shared/src/index.ts`
+- Database schema/init: `apps/web/src/server/db/`
+- Services and route handlers:
+  - `apps/web/src/server/services/`
+  - `apps/web/src/app/api/`
+- Tests: `apps/web/src/server/tests/`
+
+### Commands
+
+- Install: `npm install`
+- Develop (web): `npm run dev:web`
+- Develop (worker): `npm run dev:worker`
+- Develop (both): `npm run dev:all`
+- Seed demo data: `npm run demo:seed`
+- Verify: `npm run verify`
+
+## M1 — Control-doc bundle integration (docs/process only)
+
+Status: done
+
+Delivered in this plan iteration:
+
+- Added canonical control docs: `AGENTS.md`, `PLANS.md`, and this file.
+- Added implementation/reference doc trees:
+  - `docs/spec/`
+  - `docs/research/`
+  - `docs/review/`
+  - `docs/codex/`
+- Added repo-local skill entrypoints under `.agents/skills/`.
+- Added light alignment updates in:
+  - `README.md`
+  - `docs/project-blueprint.md`
+
+## Architecture notes (current)
+
+- The product is local-first and source-traceable.
+- `apps/web` currently hosts both UI and server-side logic for APIs/services.
+- `packages/shared` provides shared schemas/constants consumed by the web app.
+- Data is persisted locally and versioned by schema/service logic in the web package.
+
+## Verification expectations
+
+- Primary local verification for changes: `npm run verify`
+- CI mirrors this via `npm run ci:verify`.
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+<<<<<<< ours
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs
+=======
+>>>>>>> theirs


### PR DESCRIPTION
## Summary
- add the revised control-doc bundle into canonical repo paths
- align the imported planning docs with the current monorepo structure and commands
- link the new control docs from the contributor-facing docs without changing runtime behavior

## What Changed
- added `AGENTS.md`, `PLANS.md`, `plans/mvp_execplan.md`, repo-local skills under `.agents/skills`, and the new `docs/spec`, `docs/research`, `docs/review`, and `docs/codex` trees
- filled `docs/spec/Documentation.md` and `plans/mvp_execplan.md` with the repo's actual stack, commands, CI flow, and insertion points instead of leaving placeholder `TODO` / `UNKNOWN` values
- updated `README.md` and `docs/project-blueprint.md` to point contributors at the canonical control docs

## Verification
- npm run verify
