### PR TITLE
[codex] Align MVP release docs

### DIFF
--- a/docs/review/mvp-rc-notes.md
+++ b/docs/review/mvp-rc-notes.md
@@ -1,0 +1,46 @@
+# MVP Release Candidate Notes
+
+## Candidate summary
+
+This release candidate already supports the core governed knowledge loop:
+
+- import local source material
+- compile it into evidence-backed knowledge artifacts
+- review pending nodes, capability signals, and mistake patterns
+- generate a Passport manifest
+- narrow delivery through Visa bundles
+- export governed downstream packages for agent/avatar use
+
+## Canonical MVP mental model
+
+Externally, the MVP should be explained through three primary user-facing objects:
+
+- Passport
+- Focus Card
+- Topic Card
+
+The implementation still contains richer internal layers and compatibility pages, but the release candidate should be narrated Passport-first rather than as a broad future platform.
+
+## Canonical access model
+
+MVP scope is limited to:
+
+- `passport_read`
+- `topic_read`
+- `writeback_candidate`
+
+No other grant scope should be treated as canonical in release docs, UI copy, or review guidance.
+
+## Known non-blocking limitations
+
+- The operator UI still exposes more advanced/internal surfaces than the final P0 mental model.
+- No dedicated formatter or lint command exists yet; the release verification baseline remains `npm run verify`.
+- The bounded research/evaluator loop is still blocked because no fixed evaluator and checked-in fixture harness exist.
+
+## Release gate
+
+Do not call the MVP release candidate ready unless:
+
+- `npm run verify` is green
+- manual smoke checks in `docs/review/mvp-release-checklist.md` are completed
+- top-level UI exposure has been narrowed to the intended MVP path without breaking compatible routes

--- a/docs/review/mvp-release-checklist.md
+++ b/docs/review/mvp-release-checklist.md
@@ -1,0 +1,32 @@
+# MVP Release Checklist
+
+Use this checklist before declaring an MVP release candidate.
+
+## Verification
+
+- [ ] `npm run verify` passes from repo root.
+- [ ] `apps/web/src/server/tests/mvp.test.ts` passes as part of the normal test run.
+- [ ] `apps/web/src/server/tests/release-smoke.test.ts` passes as part of the normal test run.
+- [ ] Production build completes through `npm run build`.
+
+## Product smoke checks
+
+- [ ] Start the app with `npm run dev:all`.
+- [ ] Import at least one source from `/inbox` and confirm a compilation run completes.
+- [ ] Open `/review` and accept or reject at least one pending item.
+- [ ] Generate a passport from `/passport` and confirm the human and machine outputs render.
+- [ ] Create and revoke a visa from `/visas`, then confirm the access/revoke state is reflected.
+- [ ] Create an export package from `/exports` and confirm the download action works.
+
+## Governance and safety
+
+- [ ] Grant and visa flows only use the canonical MVP scopes: `passport_read`, `topic_read`, `writeback_candidate`.
+- [ ] Audit log entries are created for governed mutations and access-related actions.
+- [ ] Backup creation works and restore still targets an isolated directory instead of overwriting the live runtime.
+
+## Documentation
+
+- [ ] `README.md` still reflects the current development and verification commands.
+- [ ] `docs/spec/Documentation.md` matches the current stack, command surface, and repo layout.
+- [ ] `plans/mvp_execplan.md` matches the real implementation status rather than a blank-slate milestone ordering.
+- [ ] `docs/review/mvp-rc-notes.md` is up to date for the current release candidate.

--- a/docs/spec/Documentation.md
+++ b/docs/spec/Documentation.md
@@ -88,16 +88,20 @@ This file is updated as the repository is explored and changed.
 - status: completed in the control-doc alignment PR
 
 ### M1
-- status: not started
+- status: in progress
+- note: baseline schema and persistence already exist; remaining work is consistency tightening around MVP terminology, traceability, and permissions.
 
 ### M2
-- status: not started
+- status: in progress
+- note: compile, learner-state, and passport generation flows already exist; remaining work is fixture/release discipline and sharper MVP framing.
 
 ### M3
-- status: not started
+- status: in progress
+- note: visa, grant, audit, and governed delivery paths exist; remaining work is enforcing the narrowed MVP scope model across docs and UI.
 
 ### M4
-- status: not started
+- status: in progress
+- note: a usable operator UI exists today; remaining work is reducing top-level concept sprawl and emphasizing the Passport-first flow.
 
 ### M5
 - status: blocked pending evaluator + fixtures
@@ -107,3 +111,4 @@ This file is updated as the repository is explored and changed.
 - No dedicated formatter or lint command exists yet, so plans and PRs should not claim those validations until they are added.
 - No fixed evaluator or checked-in compile fixture harness exists yet, so bounded research-loop work remains blocked.
 - The current app already exposes more internal surfaces than the narrowed P0 framing, so future milestones need to tighten presentation without destabilizing existing functionality.
+- The local dirty workspace used during previous GitHub/API-assisted merges is not a trustworthy baseline; continued release work should start from a clean clone or worktree.

--- a/plans/mvp_execplan.md
+++ b/plans/mvp_execplan.md
@@ -109,7 +109,7 @@ Validation:
 - tests
 - migration and seed validation if applicable
 
-Status: NOT STARTED
+Status: IN PROGRESS. The repo already contains baseline schema, persistence, and sample data paths for these entities; current work is narrowing the model and documentation to the MVP contract.
 
 ---
 
@@ -146,7 +146,7 @@ Validation:
 - fixture/golden validation
 - benchmark harness only if it already exists
 
-Status: NOT STARTED
+Status: IN PROGRESS. A working compile pipeline, learner-state generation, and passport regeneration path already exist; current work is focused on consistency, fixture discipline, and release hardening.
 
 ---
 
@@ -184,7 +184,7 @@ Validation:
 - tests
 - contract tests for access control and writeback behavior
 
-Status: NOT STARTED
+Status: IN PROGRESS. Visa, grant, audit, and writeback-adjacent flows already exist; current work is tightening them to the canonical MVP scopes and review boundaries.
 
 ---
 
@@ -221,7 +221,7 @@ Validation:
 - tests where the frontend stack supports them
 - manual smoke test notes
 
-Status: NOT STARTED
+Status: IN PROGRESS. The app already has a broad operator UI; current work is reducing top-level exposure so the MVP reads as Passport-first instead of platform-first.
 
 ---
 
@@ -303,21 +303,21 @@ Status: BLOCKED until M2 + evaluator exist
 ## Status summary
 
 - M0: completed
-- M1: not started
-- M2: not started
-- M3: not started
-- M4: not started
+- M1: in progress
+- M2: in progress
+- M3: in progress
+- M4: in progress
 - M5: blocked
 
 ## Notes for the current run
 
-This control-doc bundle PR is intentionally docs/process-only:
+The repository is past a blank-slate MVP state:
 
-- imported the canonical control docs and repo-local skills
-- aligned M0 inventory content with the actual monorepo
-- left runtime behavior unchanged
+- baseline import, compile, review, passport, visa, export, and avatar flows already exist in code and tests
+- current work is release hardening and narrowing the exposed user-facing surface to the intended MVP mental model
 
-Default starting instruction unless the human says otherwise:
+Default release-candidate instruction unless the human says otherwise:
 
-- do **M1 only** next
-- do **not** start M2+ without explicit instruction
+- align docs and milestone status to implemented reality
+- tighten top-level UI exposure without deleting compatible routes
+- keep `npm run verify` green throughout


### PR DESCRIPTION
## Summary
- align MVP execution/status docs with implemented reality
- add an explicit MVP release checklist and RC notes
- keep release gating centered on the repo's real verify and smoke flows

## What Changed
- moved M1-M4 in the execution plan from "not started" to in-progress, with notes that baseline implementation already exists
- updated repository documentation to reflect release-hardening and clean-baseline expectations
- added `docs/review/mvp-release-checklist.md` and `docs/review/mvp-rc-notes.md`

## Verification
- npm ci
- npm run verify
