### PR TITLE
[codex] Narrow MVP UI exposure

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { formatDistanceToNow } from "date-fns";
+import Link from "next/link";
 
 import { PageShell } from "@/components/page-shell";
 import { SectionCard, StatTile, StatusBadge } from "@/components/ui";
@@ -18,6 +19,20 @@ export default async function DashboardPage() {
         <StatTile label="Pending Review" value={stats.pendingReview} hint="Compiled nodes waiting for user review" />
         <StatTile label="Active Focus" value={stats.activeFocusCard?.title ?? "none"} hint={stats.activeFocusCard?.priority ?? "No active focus card"} />
       </section>
+
+      <SectionCard title="Primary Operator Path" description="For the MVP release candidate, keep the top-level workflow narrow: prepare context, publish a passport, mount it, and review what comes back.">
+        <div className="flex flex-wrap gap-3">
+          <Link href="/passport" className="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-medium text-white">
+            Open Passport
+          </Link>
+          <Link href="/visas" className="rounded-full border border-[var(--line)] px-5 py-3 text-sm">
+            Open Mount Center
+          </Link>
+          <Link href="/review" className="rounded-full border border-[var(--line)] px-5 py-3 text-sm">
+            Open Review Queue
+          </Link>
+        </div>
+      </SectionCard>
 
       <div className="grid gap-6 lg:grid-cols-2">
         <SectionCard title="Current User Context" description="This is the high-level layer an AI should understand before it reads deeper knowledge.">

--- a/apps/web/src/app/knowledge/page.tsx
+++ b/apps/web/src/app/knowledge/page.tsx
@@ -71,6 +71,20 @@ export default async function KnowledgePage(props: { searchParams?: Promise<Reco
           )}
         </SectionCard>
       </div>
+
+      <SectionCard title="Advanced Tools" description="These routes remain available for deeper operator work, but they are no longer first-layer navigation in the MVP release candidate.">
+        <div className="flex flex-wrap gap-3">
+          <Link href="/signals" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+            Open Signals
+          </Link>
+          <Link href="/postcards" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+            Open Topic Cards
+          </Link>
+          <Link href="/research" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm">
+            Open Research
+          </Link>
+        </div>
+      </SectionCard>
     </PageShell>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
             Help any AI understand your foundation, current goal, and blind spots without starting from zero.
           </h1>
           <p className="mt-6 text-lg leading-8 text-[var(--muted)]">
-            This system compiles private materials into signals, postcards, passports, visas, governed avatars, and export bundles. The passport is the canonical AI entry object. Everything deeper stays explicitly authorized.
+            This system compiles private materials into focus-aware topic cards, passports, visas, governed avatars, and export bundles. The passport is the canonical AI entry object. Everything deeper stays explicitly authorized.
           </p>
         </div>
 
@@ -18,30 +18,30 @@ export default function HomePage() {
           <Link href="/dashboard" className="rounded-full bg-[var(--accent)] px-6 py-3 text-sm font-medium text-white">
             Open Dashboard
           </Link>
-          <Link href="/signals" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
-            Open Signals
-          </Link>
           <Link href="/passport" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
             Open Passport
           </Link>
           <Link href="/visas" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
             Open Mount Center
           </Link>
+          <Link href="/review" className="rounded-full border border-[var(--line)] px-6 py-3 text-sm">
+            Open Review
+          </Link>
         </div>
 
         <section className="grid gap-6 lg:grid-cols-3">
           <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">
             <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Core Loop</p>
-            <p className="mt-4 text-xl font-semibold">Import {"->"} Compile {"->"} Signals {"->"} Passport</p>
+            <p className="mt-4 text-xl font-semibold">Import {"->"} Compile {"->"} Topic Cards {"->"} Passport</p>
             <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-              Turn raw sources into accepted knowledge, capability signals, mistake patterns, and an active focus card before any AI reads deeper.
+              Turn raw sources into accepted knowledge, topic cards, capability signals, mistake patterns, and an active focus card before any AI reads deeper.
             </p>
           </article>
           <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">
             <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Mount Layer</p>
             <p className="mt-4 text-xl font-semibold">Passport {"->"} Visa {"->"} Feedback</p>
             <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-              Narrow the passport into a read-only visa bundle with logs, expiry, redaction, and lightweight external flowback.
+              Narrow the passport into a scoped visa bundle with logs, expiry, redaction, and lightweight external flowback.
             </p>
           </article>
           <article className="rounded-[28px] border border-[var(--line)] bg-white/70 p-6">

--- a/apps/web/src/app/passport/page.tsx
+++ b/apps/web/src/app/passport/page.tsx
@@ -21,7 +21,7 @@ export default async function PassportPage() {
   ]);
 
   return (
-    <PageShell currentPath="/passport" title="Passport" subtitle="Publish the canonical AI entry object: postcards, active focus, capability signals, and blind spots in one governed manifest">
+    <PageShell currentPath="/passport" title="Passport" subtitle="Publish the canonical AI entry object: topic cards, active focus, capability signals, and blind spots in one governed manifest">
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <SectionCard title="Passport and Backup Controls" description="Passport generation packages the context an AI should read first. Backup remains a secondary recovery layer.">
           <div className="space-y-6">
@@ -43,7 +43,7 @@ export default async function PassportPage() {
           </div>
         </SectionCard>
         <div className="space-y-6">
-          <SectionCard title="Passport Snapshots" description="Each passport now captures what an AI should know about the user before it reads deeper knowledge.">
+          <SectionCard title="Passport Snapshots" description="Each passport now captures what an AI should know first: focus, topic cards, signals, and governed boundaries.">
             <div className="space-y-4">
               {passports.map((passport) => (
                 <article key={passport.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
@@ -56,7 +56,7 @@ export default async function PassportPage() {
                   </div>
                   <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
                     <span className="rounded-full bg-black/5 px-3 py-1">nodes {passport.includeNodeIds.length}</span>
-                    <span className="rounded-full bg-black/5 px-3 py-1">cards {passport.includePostcardIds.length}</span>
+                    <span className="rounded-full bg-black/5 px-3 py-1">topic cards {passport.includePostcardIds.length}</span>
                     <span className="rounded-full bg-black/5 px-3 py-1">
                       themes {Array.isArray(passport.machineManifest.themeMap) ? passport.machineManifest.themeMap.length : 0}
                     </span>

--- a/apps/web/src/app/postcards/page.tsx
+++ b/apps/web/src/app/postcards/page.tsx
@@ -12,20 +12,20 @@ export default async function PostcardsPage() {
   const postcards = await listPostcards(getAppContext());
 
   return (
-    <PageShell currentPath="/postcards" title="Postcards" subtitle="Compress important knowledge into composable, traceable communication units">
+    <PageShell currentPath="/postcards" title="Topic Cards" subtitle="Compress important knowledge into traceable topic cards without changing the underlying postcard implementation">
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-        <SectionCard title="Create Postcard" description="Supports manual authoring or AI-assisted generation from related nodes and sources.">
+        <SectionCard title="Create Topic Card" description="Supports manual authoring or AI-assisted generation from related nodes and sources.">
           <div className="space-y-4">
             <div className="flex flex-wrap items-center gap-3 rounded-3xl border border-[var(--line)] bg-white/80 p-4 text-sm">
-              <span className="text-[var(--muted)]">Postcards can now be projected outward through visa bundles and secret links.</span>
+              <span className="text-[var(--muted)]">Topic cards can be projected outward through visa bundles and secret links.</span>
               <Link href="/visas" className="rounded-full border border-[var(--line)] px-4 py-2">
-                Open Visa Workshop
+                Open Mount Center
               </Link>
             </div>
             <PostcardForm />
           </div>
         </SectionCard>
-        <SectionCard title="Postcard Library" description="These entries can later be composed into a passport.">
+        <SectionCard title="Topic Card Library" description="These entries can later be composed into a passport.">
           <div className="space-y-4">
             {postcards.map((card) => (
               <article key={card.id} className="rounded-3xl border border-[var(--line)] bg-white/80 p-4">
@@ -49,7 +49,7 @@ export default async function PostcardsPage() {
                 </div>
               </article>
             ))}
-            {postcards.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no postcards yet.</p> : null}
+            {postcards.length === 0 ? <p className="text-sm text-[var(--muted)]">There are no topic cards yet.</p> : null}
           </div>
         </SectionCard>
       </div>

--- a/apps/web/src/app/v/[token]/page.tsx
+++ b/apps/web/src/app/v/[token]/page.tsx
@@ -66,7 +66,7 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
     <main className="mx-auto min-h-screen max-w-5xl px-5 py-10">
       <div className="space-y-6">
         <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-8">
-          <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Read-only visa</p>
+          <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Scoped visa</p>
           <h1 className="mt-3 text-4xl font-semibold tracking-tight">{visa.title}</h1>
           <p className="mt-4 text-base leading-7 text-[var(--muted)]">
             Audience: {visa.audienceLabel} · Source: {visa.passportId ? "passport snapshot" : "direct selection"}
@@ -84,7 +84,7 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
                 ? `machine downloads ${visa.machineDownloadCount}/${visa.maxMachineDownloads}`
                 : `machine downloads ${visa.machineDownloadCount}`}
             </StatusBadge>
-            <StatusBadge>read-only</StatusBadge>
+            <StatusBadge>scoped access</StatusBadge>
           </div>
           {visa.allowMachineDownload ? (
             <a className="mt-6 inline-flex rounded-full border border-[var(--line)] px-4 py-2 text-sm" href={visa.machinePath ?? "#"}>
@@ -141,7 +141,7 @@ export default async function PublicVisaPage(props: { params: Promise<{ token: s
           <p className="text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Lightweight flowback</p>
           <h2 className="mt-3 text-2xl font-semibold">Send feedback or ask a scoped question</h2>
           <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-            This page is read-only. You can still leave feedback, a narrow question, or a collaboration intent. Your submission enters the owner’s internal review queue.
+            This page grants scoped access only. You can still leave feedback, a narrow question, or a collaboration intent. Your submission enters the owner’s internal review queue.
           </p>
           <div className="mt-6">
             <ExternalVisaFeedbackForm token={params.token} />

--- a/apps/web/src/app/visas/[id]/page.tsx
+++ b/apps/web/src/app/visas/[id]/page.tsx
@@ -130,14 +130,14 @@ export default async function VisaDetailPage(props: { params: Promise<{ id: stri
           </div>
         </SectionCard>
 
-        <SectionCard title="Bundle Contents" description="The currently included node and postcard counts for this visa snapshot.">
+        <SectionCard title="Bundle Contents" description="The currently included node and topic-card counts for this visa snapshot.">
           <div className="space-y-4 text-sm">
             <div className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">
               <p className="font-medium">Nodes</p>
               <p className="mt-2 text-[var(--muted)]">{visa.includeNodeIds.length}</p>
             </div>
             <div className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">
-              <p className="font-medium">Postcards</p>
+              <p className="font-medium">Topic Cards</p>
               <p className="mt-2 text-[var(--muted)]">{visa.includePostcardIds.length}</p>
             </div>
             <div className="rounded-2xl border border-[var(--line)] bg-white/80 p-4">

--- a/apps/web/src/app/visas/page.tsx
+++ b/apps/web/src/app/visas/page.tsx
@@ -42,7 +42,7 @@ export default async function VisasPage() {
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <SectionCard
           title="Create Visa Bundle"
-          description="Begin with the passport context, then narrow nodes, postcards, access limits, and machine-download policy for one specific mount."
+          description="Begin with the passport context, then narrow nodes, topic cards, access limits, and machine-download policy for one specific mount."
         >
           <VisaForm
             passports={passports.map((passport) => ({
@@ -74,7 +74,7 @@ export default async function VisasPage() {
                 <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--muted)]">
                   <span className="rounded-full bg-black/5 px-3 py-1">audience {visa.audienceLabel}</span>
                   <span className="rounded-full bg-black/5 px-3 py-1">nodes {visa.includeNodeIds.length}</span>
-                  <span className="rounded-full bg-black/5 px-3 py-1">cards {visa.includePostcardIds.length}</span>
+                  <span className="rounded-full bg-black/5 px-3 py-1">topic cards {visa.includePostcardIds.length}</span>
                   <span className="rounded-full bg-black/5 px-3 py-1">{visa.expiresAt ? `expires ${visa.expiresAt}` : "no expiry"}</span>
                   <span className="rounded-full bg-black/5 px-3 py-1">
                     {visa.maxAccessCount ? `views ${visa.accessCount}/${visa.maxAccessCount}` : `views ${visa.accessCount}`}
@@ -122,9 +122,9 @@ export default async function VisasPage() {
 
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-semibold">Postcards</h4>
+              <h4 className="text-sm font-semibold">Topic Cards</h4>
               <Link href="/postcards" className="text-sm text-[var(--accent)]">
-                Open Postcards
+                Open Topic Cards
               </Link>
             </div>
             {postcardRows.map((card) => (
@@ -135,7 +135,7 @@ export default async function VisasPage() {
                 </p>
               </article>
             ))}
-            {postcardRows.length === 0 ? <p className="text-sm text-[var(--muted)]">No postcards are available yet.</p> : null}
+            {postcardRows.length === 0 ? <p className="text-sm text-[var(--muted)]">No topic cards are available yet.</p> : null}
           </div>
 
           <div className="space-y-3">

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -8,16 +8,13 @@ const coreNavigation = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/inbox", label: "Inbox", icon: Files },
   { href: "/knowledge", label: "Knowledge", icon: LibraryBig },
-  { href: "/signals", label: "Signals", icon: Target },
-  { href: "/postcards", label: "Postcards", icon: Activity },
   { href: "/passport", label: "Passport", icon: Shield },
+  { href: "/visas", label: "Mount Center", icon: Key },
   { href: "/review", label: "Review Queue", icon: BadgeCheck },
-  { href: "/research", label: "Research", icon: FileSearch }
 ];
 
 const advancedNavigation = [
   { href: "/outputs", label: "Outputs", icon: BookOpenText },
-  { href: "/visas", label: "Mount Center", icon: Key },
   { href: "/avatars", label: "Avatars", icon: Bot },
   { href: "/exports", label: "Exports", icon: Download },
   { href: "/policies", label: "Policies", icon: SlidersHorizontal },
@@ -102,7 +99,7 @@ export function PageShell(props: { currentPath: string; title: string; subtitle:
           <div className="mt-8 rounded-3xl border border-[var(--line)] bg-[var(--surface-strong)] p-4 text-sm text-[var(--muted)]">
             <p className="font-medium text-[var(--ink)]">Primary Loop</p>
             <p className="mt-2 leading-6">
-              Import, compile, synthesize signals, publish postcards, generate a passport, and mount only what an AI needs.
+              Import source material, compile evidence-backed knowledge, publish topic cards, generate a passport, and mount only what an AI needs.
             </p>
           </div>
         </aside>

--- a/apps/web/src/server/services/visas.ts
+++ b/apps/web/src/server/services/visas.ts
@@ -220,7 +220,7 @@ function renderVisaHumanMarkdown(input: {
     `# ${input.title}`,
     "",
     `Audience: ${input.audienceLabel}`,
-    "Access: Read-only secret link",
+    "Access: Scoped secret link",
     `Expiry: ${input.expiresAt ?? "No expiry"}`,
     `Origin: ${input.passportTitle ? `Passport snapshot · ${input.passportTitle}` : "Direct visa selection"}`
   ];
@@ -261,7 +261,7 @@ function renderVisaHumanMarkdown(input: {
   }
 
   if (input.cards.length) {
-    lines.push("", "## Postcards");
+    lines.push("", "## Topic Cards");
     for (const card of input.cards) {
       const sourceCount = Array.from(new Set(card.relatedSourceIds)).filter((id) => input.sourceMap.has(id)).length;
       lines.push(


### PR DESCRIPTION
## Summary
- narrow top-level navigation to the MVP six-page operator path
- keep `/signals`, `/postcards`, and `/research` available as compatibility routes instead of first-layer nav
- shift outward-facing copy from `Postcards` / `read-only` wording toward `Topic Cards` / scoped access

## What Changed
- removed `Signals`, `Postcards`, and `Research` from core navigation and moved `Mount Center` into the core path
- added clear CTA paths on Dashboard and Knowledge so advanced routes remain reachable without top-level promotion
- updated Passport, Mount Center, Topic Card, public visa, and home-page copy to match the MVP release-candidate framing

## Verification
- npm run verify
