### PR TITLE
Temporary: run public Algothon leaderboard capture

### DIFF
--- a/tmp/algothon-leaderboard-trigger.txt
+++ b/tmp/algothon-leaderboard-trigger.txt
@@ -1,0 +1,1 @@
+Capture the public Algothon leaderboard on 2026-08-07.


### PR DESCRIPTION
Temporary public-leaderboard capture trigger; closed after the audit. No merge.